### PR TITLE
Make transformers configurable

### DIFF
--- a/robotidy/app.py
+++ b/robotidy/app.py
@@ -1,13 +1,14 @@
+from typing import List, Tuple, Dict
 from robotidy.transformers import load_transformers
 
 
 class Robotidy:
-    def __init__(self, transformers):
+    def __init__(self, transformers: List[Tuple[str, Dict]]):
         transformer_names = [transformer[0] for transformer in transformers]
         self.transformers = load_transformers(set(transformer_names))
         self.configure_transformers(transformers)
 
-    def configure_transformers(self, transformer_config):
+    def configure_transformers(self, transformer_config: List[Tuple[str, Dict]]):
         for name, params in transformer_config:
             if not params:
                 continue

--- a/robotidy/app.py
+++ b/robotidy/app.py
@@ -3,4 +3,16 @@ from robotidy.transformers import load_transformers
 
 class Robotidy:
     def __init__(self, transformers):
-        self.transformers = load_transformers(set(transformers))
+        transformer_names = [transformer[0] for transformer in transformers]
+        self.transformers = load_transformers(set(transformer_names))
+        self.configure_transformers(transformers)
+
+    def configure_transformers(self, transformer_config):
+        for name, params in transformer_config:
+            if not params:
+                continue
+            for param_name, value in params.items():
+                if param_name in self.transformers[name].configurables:
+                    setattr(self.transformers[name], param_name, value)
+                else:
+                    raise ValueError(f"Invalid configurable name: '{param_name}' for transformer: '{name}'")

--- a/robotidy/cli.py
+++ b/robotidy/cli.py
@@ -1,7 +1,6 @@
 import click
 from robotidy.version import __version__
 from robotidy.app import Robotidy
-from robotidy.transformers import load_transfomers_names
 
 
 class TransformType(click.ParamType):

--- a/robotidy/cli.py
+++ b/robotidy/cli.py
@@ -4,14 +4,33 @@ from robotidy.app import Robotidy
 from robotidy.transformers import load_transfomers_names
 
 
+class TransformType(click.ParamType):
+    name = "transform"
+
+    def convert(self, value, param, ctx):
+        name, *configs = value.split(':')
+        configurations = {}
+        try:
+            for config in configs:
+                key, value = config.split('=', maxsplit=1)
+                configurations[key] = value
+        except ValueError:
+            exc = f'Invalid {name} transformer configuration. ' \
+                  f'Parameters should be provided in format name=value, delimited by :'
+            raise ValueError(exc)
+        return name, configurations
+
+
 @click.command()
 @click.option(
     '--transform',
-    type=click.Choice(load_transfomers_names(), case_sensitive=False),
-    required=True,
+    type=TransformType(),
     multiple=True
 )
 @click.version_option(__version__)
 def cli(transform):
     tidy = Robotidy(transform)
     print(tidy.transformers)
+    print(tidy.transformers['DummyTransformer'].some_value)
+    tidy.transformers['DummyTransformer'].some_value = 5
+    print(tidy.transformers['DummyTransformer'].some_value)

--- a/robotidy/decorators.py
+++ b/robotidy/decorators.py
@@ -1,23 +1,11 @@
 import inspect
 
 
-class configurable:  # noqa
-    """
-    Decorator to expose method as configurable parameter.
-    Decorated method should return value.
-
-    Example::
-
-        @configurable
-        def some_value(self, value):
-            # parsing for value
-            return value
-
-        def other_method(self, arg):
-           print(self.some_value)
-    """
-    def __init__(self, fun):
+class ConfigurableDecorator:
+    def __init__(self, fun, **kwargs):
         self.fun = fun
+        if 'default' in kwargs:
+            self._value = kwargs['default']
 
     def __set_name__(self, owner, name):
         if not hasattr(owner, 'configurables'):
@@ -35,6 +23,41 @@ class configurable:  # noqa
             return self._value
         except AttributeError:
             raise AttributeError(f'{owner.__name__}.{self.fun.__name__} attribute was not initialized before use')
+
+    def __call__(self, *args, **kwargs):
+        pass
+
+
+def configurable(function=None, **kwargs):
+    """
+    Decorator to expose method as configurable parameter.
+    Decorated method should return value.
+
+    Example::
+
+        @configurable
+        def some_value(self, value):
+            # parsing for value
+            return value
+
+        def other_method(self, arg):
+           print(self.some_value)
+
+    It is possible to pass default value with `default=` argument::
+
+        @configurable(default=10)
+
+    If the same value is initialized also in `__init__` it will be overridden in `__init__`.
+    The main difference is that if you set it in `__init__` it will go through parsing method (`some_value`).
+    On the other hand `default=` saves value directly.
+    """
+    if function:
+        return ConfigurableDecorator(function)
+    else:
+        def wrapper(function):
+            return ConfigurableDecorator(function, **kwargs)
+
+        return wrapper
 
 
 def transformer(arg=None):

--- a/robotidy/decorators.py
+++ b/robotidy/decorators.py
@@ -1,4 +1,18 @@
 class configurable:  # noqa
+    """
+    Decorator to expose method as configurable parameter.
+    Decorated method should return value.
+
+    Example::
+
+        @configurable
+        def some_value(self, value):
+            # parsing for value
+            return value
+
+        def other_method(self, arg):
+           print(self.some_value)
+    """
     def __init__(self, fun):
         self.fun = fun
 
@@ -21,5 +35,6 @@ class configurable:  # noqa
 
 
 def transformer(cls):
+    """Decorator for transformer class. Only decorated classes are loaded and used to transform the source code."""
     cls.is_transformer = True
     return cls

--- a/robotidy/decorators.py
+++ b/robotidy/decorators.py
@@ -1,0 +1,25 @@
+class configurable:  # noqa
+    def __init__(self, fun):
+        self.fun = fun
+
+    def __set_name__(self, owner, name):
+        if not hasattr(owner, 'configurables'):
+            owner.configurables = set()
+        owner.configurables.add(name)
+
+    def __set__(self, obj, value):
+        if not obj:
+            return self
+        self._value = self.fun(obj, value)
+        return self._value
+
+    def __get__(self, instance, owner):
+        try:
+            return self._value
+        except AttributeError:
+            raise AttributeError(f'{owner.__name__}.{self.fun.__name__} attribute was not initialized before use')
+
+
+def transformer(cls):
+    cls.is_transformer = True
+    return cls

--- a/robotidy/decorators.py
+++ b/robotidy/decorators.py
@@ -40,6 +40,7 @@ class configurable:  # noqa
 def transformer(arg=None):
     """Decorator for transformer class. Only decorated classes are loaded and used to transform the source code."""
 
+    # it allows to use transformer without ()
     if inspect.isclass(arg):
         return transformer()(arg)
 

--- a/robotidy/decorators.py
+++ b/robotidy/decorators.py
@@ -1,3 +1,6 @@
+import inspect
+
+
 class configurable:  # noqa
     """
     Decorator to expose method as configurable parameter.
@@ -34,7 +37,14 @@ class configurable:  # noqa
             raise AttributeError(f'{owner.__name__}.{self.fun.__name__} attribute was not initialized before use')
 
 
-def transformer(cls):
+def transformer(arg=None):
     """Decorator for transformer class. Only decorated classes are loaded and used to transform the source code."""
-    cls.is_transformer = True
-    return cls
+
+    if inspect.isclass(arg):
+        return transformer()(arg)
+
+    def decorator(cls):
+        cls.is_transformer = True
+        return cls
+
+    return decorator

--- a/robotidy/transformers.py
+++ b/robotidy/transformers.py
@@ -3,29 +3,48 @@ import sys
 
 from robot.parsing import ModelTransformer
 
+from robotidy.decorators import transformer, configurable
+
 
 def load_transformers(allowed_transformers):
     """ Dynamically load all classess from this file with attribute `name` defined in allowed_transformers """
-    transfomers = []
+    transformer_classes = {}
     classes = inspect.getmembers(sys.modules[__name__], inspect.isclass)
     for transfomer_class in classes:
         if transfomer_class[1].__name__ in allowed_transformers:
-            transfomers.append(transfomer_class[1]())
-    return transfomers
+            transformer_classes[transfomer_class[1].__name__] = transfomer_class[1]()
+    return transformer_classes
 
 
 def load_transfomers_names():
-    transfomers = []
+    transformer_names = []
     classes = inspect.getmembers(sys.modules[__name__], inspect.isclass)
     for transfomer_class in classes:
-        if issubclass(transfomer_class[1], ModelTransformer) and transfomer_class[1].__name__ != 'ModelTransformer':
-            transfomers.append(transfomer_class[1].__name__)
-    return transfomers
+        if getattr(transfomer_class[1], 'is_transformer', False):
+            transformer_names.append(transfomer_class[1].__name__)
+    return transformer_names
 
 
+@transformer
 class DummyTransformer(ModelTransformer):
-    pass
+    def __init__(self):
+        self.some_value = 10
+
+    @configurable
+    def some_value(self, value):
+        return int(value) + 1
 
 
+@transformer
 class AnotherTransformer(ModelTransformer):
+    def __init__(self):
+        self.other_value = 5
+
+    @configurable
+    def other_value(self, value):
+        value = value * 10
+        return value
+
+
+class NotATransformer(ModelTransformer):
     pass

--- a/robotidy/transformers.py
+++ b/robotidy/transformers.py
@@ -11,18 +11,12 @@ def load_transformers(allowed_transformers):
     transformer_classes = {}
     classes = inspect.getmembers(sys.modules[__name__], inspect.isclass)
     for transfomer_class in classes:
-        if transfomer_class[1].__name__ in allowed_transformers:
+        if not allowed_transformers:
+            if getattr(transfomer_class[1], 'is_transformer', False):
+                transformer_classes[transfomer_class[1].__name__] = transfomer_class[1]()
+        elif transfomer_class[1].__name__ in allowed_transformers:
             transformer_classes[transfomer_class[1].__name__] = transfomer_class[1]()
     return transformer_classes
-
-
-def load_transfomers_names():
-    transformer_names = []
-    classes = inspect.getmembers(sys.modules[__name__], inspect.isclass)
-    for transfomer_class in classes:
-        if getattr(transfomer_class[1], 'is_transformer', False):
-            transformer_names.append(transfomer_class[1].__name__)
-    return transformer_names
 
 
 @transformer

--- a/robotidy/transformers.py
+++ b/robotidy/transformers.py
@@ -32,6 +32,7 @@ class DummyTransformer(ModelTransformer):
 
     @configurable
     def some_value(self, value):
+        """ configurable property with name `some_value`. Parse and return expected value to save it """
         return int(value) + 1
 
 
@@ -42,6 +43,7 @@ class AnotherTransformer(ModelTransformer):
 
     @configurable
     def other_value(self, value):
+        """ configurable property with name `other_value`. Parse and return expected value to save it """
         value = value * 10
         return value
 

--- a/tests/utest/test_decorators.py
+++ b/tests/utest/test_decorators.py
@@ -5,10 +5,15 @@ from robotidy.decorators import transformer, configurable
 
 class TestDecorators:
     def test_transform_decorator(self):
-        @transformer
+        @transformer()
         class TestingTransformer:
             pass
+
+        class NotATransfomer:
+            pass
+
         assert getattr(TestingTransformer, 'is_transformer', False)
+        assert not hasattr(NotATransfomer, 'is_transformer')
 
     def test_configurable_init(self):
         @transformer

--- a/tests/utest/test_decorators.py
+++ b/tests/utest/test_decorators.py
@@ -63,3 +63,18 @@ class TestDecorators:
         transform = TestingTransformer()
         transform.some_value = 5
         assert getattr(transform, 'some_value', 0) == 7
+
+    def test_configurable_no_value_set(self):
+        @transformer
+        class TestingTransformer:
+            @configurable()
+            def some_value(self, value):
+                return value + 2
+
+        transform = TestingTransformer()
+
+        with pytest.raises(AttributeError) as err:
+            print(transform.some_value)
+            assert 'TestingTransformer.some_value attribute was not initialized before use' in str(err)
+        transform.some_value = 15
+        assert getattr(transform, 'some_value', 0) == 17

--- a/tests/utest/test_decorators.py
+++ b/tests/utest/test_decorators.py
@@ -1,0 +1,36 @@
+import pytest
+
+from robotidy.decorators import transformer, configurable
+
+
+class TestDecorators:
+    def test_transform_decorator(self):
+        @transformer
+        class TestingTransformer:
+            pass
+        assert getattr(TestingTransformer, 'is_transformer', False)
+
+    def test_configurable_init(self):
+        @transformer
+        class TestingTransformer:
+            def __init__(self):
+                self.some_value = 10
+
+            @configurable
+            def some_value(self, value):
+                return value + 2
+        transform = TestingTransformer()
+        assert getattr(transform, 'some_value', 0) == 12
+
+    def test_configurable_override(self):
+        @transformer
+        class TestingTransformer:
+            def __init__(self):
+                self.some_value = 10
+
+            @configurable
+            def some_value(self, value):
+                return value + 2
+        transform = TestingTransformer()
+        transform.some_value = 5
+        assert getattr(transform, 'some_value', 0) == 7

--- a/tests/utest/test_decorators.py
+++ b/tests/utest/test_decorators.py
@@ -27,13 +27,37 @@ class TestDecorators:
         transform = TestingTransformer()
         assert getattr(transform, 'some_value', 0) == 12
 
-    def test_configurable_override(self):
+    def test_configurable_with_default(self):
+        @transformer
+        class TestingTransformer:
+            @configurable(default=15)
+            def some_value(self, value):
+                return value + 2
+        transform = TestingTransformer()
+        assert getattr(transform, 'some_value', 0) == 15
+
+    def test_configurable_with_default_and_init(self):
+        """First the value is set to 15 directly. Then in `__init__` some_value(10) is called which returns 10 + 2. """
         @transformer
         class TestingTransformer:
             def __init__(self):
                 self.some_value = 10
 
-            @configurable
+            @configurable(default=15)
+            def some_value(self, value):
+                return value + 2
+        transform = TestingTransformer()
+        assert getattr(transform, 'some_value', 0) == 12
+
+    def test_configurable_override(self):
+        """ Any default value should be overriden by direct assigment
+        (it should call some_value(5) which returns 5+2) """
+        @transformer
+        class TestingTransformer:
+            def __init__(self):
+                self.some_value = 10
+
+            @configurable(default=15)
             def some_value(self, value):
                 return value + 2
         transform = TestingTransformer()


### PR DESCRIPTION
Implements #4 

We're still in draft phase so all of our code is subject to big changes - but please comment if it's going in good/bad directotion. Every input is welcome!

Added `@transform` decorator - only transformers with this decorator will be automatically loaded (it's step in direction of explicit loading). 
When none transformer is set with `--transform` option robotidy will load all transformer with `@transform` decorator set. Otherwise it will filter out by --transform names.

Added `@configurable` decorator - it behaves similarly as Python property (with the difference that we should return value from our decorated function. Allow to change property value through cli configuration. For example this class:
```
@transformer
class SomeClass:
    def __init__(self):
        self.my_param = 5

    @configurable
    def my_param(self, value):
         parsed = int(value) + 5
         return parsed
```
invoked with:
```
robotidy --transform SomeClass:my_param:30
```

Will initialize SomeClass with my_param = 5, then it will load the value from configuration (int(30) + 5)  = 35. When accessed later my_param will return 35:
```
def transform(self, model):
     print(self.some_param)
> 35
```
     