### PR TITLE
Add toml to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         'robotframework @ https://github.com/robotframework/robotframework/archive/master.zip',
-        'Click>=7.0'
+        'Click>=7.0',
+        'toml>=0.10.2'
     ],
     extras_requires={
         'dev': ['pytest', 'pylama', 'pylama_pylint', 'coverage'],


### PR DESCRIPTION
Installing `robotframework-tidy` in a clear virtualenv and running `robotidy` produces the following traceback:

```
Traceback (most recent call last):
  File "/home/mrmino/.virtualenvs/tmp-97b75d1967920bd/bin/robotidy", line 5, in <module>
    from robotidy.cli import cli
  File "/home/mrmino/.virtualenvs/tmp-97b75d1967920bd/lib/python3.8/site-packages/robotidy/cli.py", line 12, in <module>
    import toml
ModuleNotFoundError: No module named 'toml'
```

This PR fixes that. [The latest version of `toml` as of writing this is 0.10.2](https://pypi.org/project/toml/#history).