### PR TITLE
Add pre-commit hook manifest file

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: robotidy
+    name: robotidy
+    entry: robotidy
+    files: '.*\.(robot|resource)$'
+    language: python
+    description: "RobotFramework source code formatter"


### PR DESCRIPTION
Resolves #37. Sorry for being late... again...

This is quite basic. The hook works only on `*.robot` files - pre-commit requires a regex here, as the identification library it uses doesn't recognize RobotFramework source code files. I haven't tested it fully yet, i.e. on all the git hooks it would normally be run by pre-commit.

References: [list of yaml keys with descriptions](https://pre-commit.com/#creating-new-hooks).

A good way of testing it is: `pre-commit try-repo https://github.com/MrMino/robotframework-tidy.git --ref as_precommit_hook --all-files` - this takes the hook straight from the fork under this PR. **Obligatory disclaimer to all, because I'm a chicken :wink: :** do not trust me about it, this command runs the code from my branch (the one from this PR); check it first, I take no responsibility for what this code does to the repository you run it on.


