### PR TITLE
Add docs to SplitTooLongLine transformer

### DIFF
--- a/robotidy/transformers/SplitTooLongLine.py
+++ b/robotidy/transformers/SplitTooLongLine.py
@@ -12,7 +12,7 @@ CONTINUATION = Token(Token.CONTINUATION)
 class SplitTooLongLine(ModelTransformer):
     """
     Split too long lines.
-    If any line in keyword call exceed given limit (configurable using ``line_length``. Default is 120) it will be
+    If any line in keyword call exceeds given length limit (configurable using ``line_length``, 120 by default) it will be
     split::
 
         Keyword With Longer Name    ${arg1}    ${arg2}    ${arg3}  # let's assume that arg2 is at 120 char

--- a/robotidy/transformers/SplitTooLongLine.py
+++ b/robotidy/transformers/SplitTooLongLine.py
@@ -2,6 +2,7 @@ from robot.api.parsing import (
     ModelTransformer,
     Token
 )
+from robotidy.decorators import check_start_end_line
 
 
 EOL = Token(Token.EOL)
@@ -9,11 +10,33 @@ CONTINUATION = Token(Token.CONTINUATION)
 
 
 class SplitTooLongLine(ModelTransformer):
+    """
+    Split too long lines.
+    If any line in keyword call exceed given limit (configurable using ``line_length``. Default is 120) it will be
+    split::
+
+        Keyword With Longer Name    ${arg1}    ${arg2}    ${arg3}  # let's assume that arg2 is at 120 char
+
+    To::
+
+        Keyword With Longer Name    ${arg1}
+        ...    ${arg2}    ${arg3}
+
+    Using ``split_on_every_arg`` (default is False) flag you can force formatter to put every argument in new line::
+
+        Keyword With Longer Name
+        ...    ${arg1}
+        ...    ${arg2}
+        ...    ${arg3}
+
+    Supports global formatting params: ``space_count``, ``--startline`` and ``--endline``.
+    """
     def __init__(self, line_length: int = 120, split_on_every_arg: bool = False):
         super().__init__()
         self.line_length = line_length
         self.split_on_every_arg = split_on_every_arg
 
+    @check_start_end_line
     def visit_KeywordCall(self, node):  # noqa
         if all(line[-1].end_col_offset < self.line_length for line in node.lines):
             return node

--- a/robotidy/transformers/SplitTooLongLine.py
+++ b/robotidy/transformers/SplitTooLongLine.py
@@ -22,7 +22,7 @@ class SplitTooLongLine(ModelTransformer):
         Keyword With Longer Name    ${arg1}
         ...    ${arg2}    ${arg3}
 
-    Using ``split_on_every_arg`` (default is False) flag you can force formatter to put every argument in new line::
+    Using ``split_on_every_arg`` flag (``False`` by default), you can force the formatter to put every argument in a new line::
 
         Keyword With Longer Name
         ...    ${arg1}


### PR DESCRIPTION
This documentation is displayed if someone runs:

```
robotidy --describe-transformer SplitTooLongLine
```
And also inside our (future) docs. 

It would be nice to get your opinion on doc content since I'm always bad at those :) @MrMino  @mnojek 