### PR TITLE
Add pyproject.toml support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,12 +96,12 @@ You can list available options by running ``robotidy --help``::
 Configuration file
 -------------------
 Robotidy can read configuration from files with ``toml`` type. Options are loaded in following order:
- - auto-discovered configuration file (``robotidy.toml``)
+ - auto-discovered configuration file (``robotidy.toml`` or ``pyproject.toml`` inside ``[tool.robotidy]`` section)
  - configuration file passed with ``--config``
  - command line arguments
 
-By default if ``--config`` argument is not used, robotidy look for configuration file named ``robotidy.toml``
-in common directories for passed sources and execution directory.
+By default if ``--config`` argument is not used, robotidy look for configuration file in common directories
+for passed sources and execution directory.
 
 It is possible to mix configuration between config file and command line, but if the same parameters are used
 command line parameter value will be used instead (reference to loading order). It's important because
@@ -110,16 +110,13 @@ in one place.
 
 Example configuration file::
 
-    [main]
-    overwrite = false
-    diff = false
-    spacecount = 4
-
-    [transformers]
-        [transformers.DiscardEmptySections]
-            allow_only_comments = true
-        [transformers.ReplaceRunKeywordIf]
-
+   overwrite = false
+   diff = false
+   spacecount = 4
+   transform = [
+       "DiscardEmptySections:allow_only_comments=True",
+       "ReplaceRunKeywordIf"
+   ]
 
 .. Badges links
 

--- a/robotidy/cli.py
+++ b/robotidy/cli.py
@@ -112,12 +112,6 @@ def find_project_root(srcs: Iterable[str]) -> Path:
     return directory
 
 
-def find_config(src_paths: Iterable[str]) -> Optional[str]:
-    project_root = find_project_root(src_paths)
-    config_path = project_root / 'robotidy.toml'
-    return str(config_path) if config_path.is_file() else None
-
-
 def find_and_read_config(src_paths: Iterable[str]) -> Dict[str, Any]:
     project_root = find_project_root(src_paths)
     config_path = project_root / 'robotidy.toml'
@@ -130,7 +124,9 @@ def find_and_read_config(src_paths: Iterable[str]) -> Dict[str, Any]:
 
 def load_toml_file(path: str) -> Dict[str, Any]:
     try:
-        return toml.load(path)
+        config = toml.load(path)
+        click.echo(f"Loaded configuration from {path}")
+        return config
     except (toml.TomlDecodeError, OSError) as e:
         raise click.FileError(
             filename=path, hint=f"Error reading configuration file: {e}"

--- a/tests/utest/test_cli.py
+++ b/tests/utest/test_cli.py
@@ -3,16 +3,18 @@ from pathlib import Path
 
 from unittest.mock import MagicMock, Mock
 import pytest
+from click import FileError
 
 from .utils import run_tidy, save_tmp_model
 from robotidy.cli import (
     find_project_root,
-    find_config,
     read_robotidy_config,
+    read_pyproject_config,
     read_config
 )
 from robotidy.utils import node_within_lines
 from robotidy.transformers.ReplaceRunKeywordIf import ReplaceRunKeywordIf
+from robotidy.version import __version__
 
 
 @patch('robotidy.app.Robotidy.save_model', new=save_tmp_model)
@@ -66,11 +68,6 @@ class TestCli:
         path = find_project_root([src])
         assert path == Path(Path(__file__).parent, 'testdata')
 
-    def test_find_config_toml_from_src(self):
-        src = Path(Path(__file__).parent, 'testdata', 'nested', 'test.robot')
-        path = find_config([src])
-        assert path == str(Path(Path(__file__).parent, 'testdata', 'robotidy.toml'))
-
     def test_read_robotidy_config(self):
         expected_config = {
             'overwrite': False,
@@ -84,6 +81,43 @@ class TestCli:
         config_path = str(Path(Path(__file__).parent, 'testdata', 'robotidy.toml'))
         config = read_robotidy_config(config_path)
         assert config == expected_config
+
+    def test_read_pyproject_config(self):
+        expected_parsed_config = {
+            'overwrite': False,
+            'diff': False,
+            'startline': 10,
+            'transform': [
+                'DiscardEmptySections:allow_only_comments=True',
+                'SplitTooLongLine'
+            ]
+        }
+        config_path = str(Path(Path(__file__).parent, 'testdata', 'only_pyproject', 'pyproject.toml'))
+        config = read_pyproject_config(config_path)
+        assert config == expected_parsed_config
+
+    def test_read_pyproject_config_e2e(self):
+        expected_parsed_config = {
+            'overwrite': 'False',
+            'diff': 'False',
+            'startline': '10',
+            'transform': [
+                'DiscardEmptySections:allow_only_comments=True',
+                'SplitTooLongLine'
+            ]
+        }
+        config_path = str(Path(Path(__file__).parent, 'testdata', 'only_pyproject'))
+        ctx_mock = MagicMock()
+        ctx_mock.params = {'src': [config_path]}
+        param_mock = Mock()
+        read_config(ctx_mock, param_mock, value=None)
+        assert ctx_mock.default_map == expected_parsed_config
+
+    def test_read_invalid_config(self):
+        config_path = str(Path(Path(__file__).parent, 'testdata', 'invalid_pyproject', 'pyproject.toml'))
+        with pytest.raises(FileError) as err:
+            read_pyproject_config(config_path)
+        assert 'Error reading configuration file: ' in str(err)
 
     def test_read_config_from_param(self):
         expected_parsed_config = {
@@ -138,6 +172,10 @@ class TestCli:
         result = run_tidy(['--describe-transformer', 'ReplaceRunKeywordIf'])
         assert ReplaceRunKeywordIf.__doc__ in result.output
 
+    def test_help(self):
+        result = run_tidy(['--help'])
+        assert f'Version: {__version__}' in result.output
+
     @pytest.mark.parametrize('source, return_status', [
         ('golden.robot', 0),
         ('not_golden.robot', 1)
@@ -148,3 +186,9 @@ class TestCli:
             ['--check', '--overwrite', '--transform', 'NormalizeSectionHeaderName', str(source)],
             exit_code=return_status
         )
+
+    def test_diff(self):
+        source = Path(Path(__file__).parent, 'testdata', 'check', 'not_golden.robot')
+        result = run_tidy(['--diff', '--no-overwrite', '--transform', 'NormalizeSectionHeaderName', str(source)])
+        assert "*** settings ***" in result.output
+        assert "*** Settings ***" in result.output

--- a/tests/utest/testdata/config.txt
+++ b/tests/utest/testdata/config.txt
@@ -3,6 +3,6 @@ overwrite = false
 diff = false
 spacecount = 4
 
-[transformers]
-    [transformers.DiscardEmptySections]
+[transform]
+    [transform.DiscardEmptySections]
         allow_only_comments = true

--- a/tests/utest/testdata/invalid_pyproject/pyproject.toml
+++ b/tests/utest/testdata/invalid_pyproject/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.robotidy]
+overwrite = false
+diff = false
+spacecount = 4
+transform = [
+   "DiscardEmptySections:allow_only_comments=True",
+   ReplaceRunKeywordIf
+]

--- a/tests/utest/testdata/only_pyproject/pyproject.toml
+++ b/tests/utest/testdata/only_pyproject/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.robotidy]
+overwrite = false
+diff = false
+startline = 10
+transform = [
+   "DiscardEmptySections:allow_only_comments=True",
+   "SplitTooLongLine"
+]

--- a/tests/utest/testdata/robotidy.toml
+++ b/tests/utest/testdata/robotidy.toml
@@ -1,9 +1,7 @@
-[main]
 overwrite = false
 diff = false
 spacecount = 4
-
-[transformers]
-    [transformers.DiscardEmptySections]
-        allow_only_comments = true
-    [transformers.ReplaceRunKeywordIf]
+transform = [
+   "DiscardEmptySections:allow_only_comments=True",
+   "ReplaceRunKeywordIf"
+]


### PR DESCRIPTION
Closes #64 

Backward not compatible changes to ``robotidy.toml`` syntax:
- no need for [main] section
- transformers should be described using following code:
```
transform = [
   "DiscardEmptySections:allow_only_comments=True",
   ReplaceRunKeywordIf
]
```