### PR TITLE
Smart Sort Keywords

### DIFF
--- a/robotidy/transformers/SmartSortKeywords.py
+++ b/robotidy/transformers/SmartSortKeywords.py
@@ -56,10 +56,8 @@ class SmartSortKeywords(ModelTransformer):
         all_empty = []
         for kw in node.body:
             kw_empty = []
-            for index in range(len(kw.body) - 1, -1, -1):
-                if not isinstance(kw.body[index], EmptyLine):
-                    break
-                kw_empty.insert(0, kw.body.pop(index))
+            while kw.body and isistance(kw.body[-1], EmptyLine):
+                kw_empty.insert(0, kw.body.pop())
             all_empty.append(kw_empty)
         return all_empty
 

--- a/robotidy/transformers/SmartSortKeywords.py
+++ b/robotidy/transformers/SmartSortKeywords.py
@@ -46,9 +46,11 @@ class SmartSortKeywords(ModelTransformer):
     def visit_KeywordSection(self, node):  # noqa
         if not node.body:
             return node
+        before, after = self.leave_only_keywords(node)
         empty_lines = self.pop_empty_lines(node)
         node.body.sort(key=self.sort_function)
         self.append_empty_lines(node, empty_lines)
+        node.body = before + node.body + after
         return node
 
     @staticmethod
@@ -56,10 +58,19 @@ class SmartSortKeywords(ModelTransformer):
         all_empty = []
         for kw in node.body:
             kw_empty = []
-            while kw.body and isistance(kw.body[-1], EmptyLine):
+            while kw.body and isinstance(kw.body[-1], EmptyLine):
                 kw_empty.insert(0, kw.body.pop())
             all_empty.append(kw_empty)
         return all_empty
+
+    def leave_only_keywords(self, node):
+        before = []
+        after = []
+        while node.body and not isinstance(node.body[0], Keyword):
+            before.append(node.body.pop(0))
+        while node.body and not isinstance(node.body[-1], Keyword):
+            after.append(node.body.pop(-1))
+        return before, after
 
     def sort_function(self, kw):
         name = kw.name

--- a/robotidy/transformers/SmartSortKeywords.py
+++ b/robotidy/transformers/SmartSortKeywords.py
@@ -3,6 +3,40 @@ from robot.parsing.model.blocks import Keyword
 
 
 class SmartSortKeywords(ModelTransformer):
+    """
+    Sort keywords in *** Keywords *** section.
+
+    By default sortin is case insensitve, but keywords with leading underscore go to the bottom. Other underscores are treated as spaces.
+    Empty lines (or lack of them) between keywords is preserved.
+
+    Following code::
+    *** Keywords ***
+    _my secrete keyword
+        Kw2
+
+    My Keyword
+        Kw1
+
+
+    my_another_cool_keyword
+    my another keyword
+        Kw3
+
+    Will be transformed to::
+    *** Keywords ***
+    my_another_cool_keyword
+
+    my another keyword
+        Kw3
+
+
+    My Keyword
+        Kw1
+    _my secrete keyword
+        Kw2
+
+    Default behavior could be changed using following parameters: ``case_insensitive``, ``ignore_leading_underscore`` and ``ignore_other_underscore``
+    """
 
     def __init__(self, case_insensitive=True, ignore_leading_underscore=False, ignore_other_underscore=True):
         self.ci = case_insensitive

--- a/robotidy/transformers/SmartSortKeywords.py
+++ b/robotidy/transformers/SmartSortKeywords.py
@@ -1,0 +1,47 @@
+from robot.api.parsing import ModelTransformer, EmptyLine
+from robot.parsing.model.blocks import Keyword
+
+
+class SmartSortKeywords(ModelTransformer):
+
+    def __init__(self, case_insensitive=True, ignore_leading_underscore=False, ignore_other_underscore=True):
+        self.ci = case_insensitive
+        self.ilu = ignore_leading_underscore
+        self.iou = ignore_other_underscore
+
+    def visit_KeywordSection(self, node):  # noqa
+        if not node.body:
+            return node
+        empty_lines = self.pop_empty_lines(node)
+        node.body.sort(key=self.sort_function)
+        self.append_empty_lines(node, empty_lines)
+        return node
+
+    @staticmethod
+    def pop_empty_lines(node):
+        all_empty = []
+        for kw in node.body:
+            kw_empty = []
+            for index in range(len(kw.body) - 1, -1, -1):
+                if not isinstance(kw.body[index], EmptyLine):
+                    break
+                kw_empty.insert(0, kw.body.pop(index))
+            all_empty.append(kw_empty)
+        return all_empty
+
+    def sort_function(self, kw):
+        name = kw.name
+        if self.ci:
+            name = name.casefold().upper()  # to make sure that letters go before underscore
+        if self.ilu:
+            name = name.lstrip('_')
+        if self.iou:
+            index = len(name) - len(name.lstrip('_'))
+            name = name[:index] + name[index:].replace("_", " ")
+        return name
+
+    @staticmethod
+    def append_empty_lines(node, empty_lines):
+        for kw, empty_lines in zip(node.body, empty_lines):
+            for line in empty_lines:
+                kw.body.append(line)

--- a/robotidy/transformers/SmartSortKeywords.py
+++ b/robotidy/transformers/SmartSortKeywords.py
@@ -35,7 +35,7 @@ class SmartSortKeywords(ModelTransformer):
     _my secrete keyword
         Kw2
 
-    Default behavior could be changed using following parameters: ``case_insensitive``, ``ignore_leading_underscore`` and ``ignore_other_underscore``
+    Default behaviour could be changed using following parameters: ``case_insensitive``, ``ignore_leading_underscore`` and ``ignore_other_underscore``
     """
 
     def __init__(self, case_insensitive=True, ignore_leading_underscore=False, ignore_other_underscore=True):

--- a/robotidy/transformers/__init__.py
+++ b/robotidy/transformers/__init__.py
@@ -16,7 +16,8 @@ TRANSFORMERS = frozenset((
     'NormalizeSectionHeaderName',
     'NormalizeSettingName',
     'ReplaceRunKeywordIf',
-    'SplitTooLongLine'
+    'SplitTooLongLine',
+    'SmartSortKeywords'
 ))
 
 

--- a/tests/atest/transformers/SmartSortKeywords/expected/empty_before_fist_keyword.robot
+++ b/tests/atest/transformers/SmartSortKeywords/expected/empty_before_fist_keyword.robot
@@ -1,0 +1,4 @@
+*** Keywords ***
+
+# My Comment
+my_kw

--- a/tests/atest/transformers/SmartSortKeywords/expected/multiple_sections.robot
+++ b/tests/atest/transformers/SmartSortKeywords/expected/multiple_sections.robot
@@ -1,0 +1,27 @@
+*** Variables ***
+${MY_VAR}    123
+
+*** Keywords ***
+
+my_another_cool_keyword
+
+
+my another keyword
+    Log Many    123
+    ...
+    # Comment
+My Keyword
+    Kw1
+    Kw3
+        one more kw
+
+_my_another_secrete_keyword
+    Log    123
+
+_my secrete keyword
+    Log    123
+
+
+
+*** Settings ***
+Library    Collections

--- a/tests/atest/transformers/SmartSortKeywords/expected/sort_.robot
+++ b/tests/atest/transformers/SmartSortKeywords/expected/sort_.robot
@@ -1,0 +1,19 @@
+*** Keywords ***
+My Keyword
+    Kw1
+    Kw3
+        one more kw
+
+
+_my secrete keyword
+    Log    123
+_my_another_secrete_keyword
+    Log    123
+
+my another keyword
+    Log Many    123
+    ...
+    # Comment
+
+my_another_cool_keyword
+

--- a/tests/atest/transformers/SmartSortKeywords/expected/sort_ci.robot
+++ b/tests/atest/transformers/SmartSortKeywords/expected/sort_ci.robot
@@ -1,0 +1,19 @@
+*** Keywords ***
+my another keyword
+    Log Many    123
+    ...
+    # Comment
+
+
+My Keyword
+    Kw1
+    Kw3
+        one more kw
+my_another_cool_keyword
+
+_my secrete keyword
+    Log    123
+
+_my_another_secrete_keyword
+    Log    123
+

--- a/tests/atest/transformers/SmartSortKeywords/expected/sort_ci_ilu.robot
+++ b/tests/atest/transformers/SmartSortKeywords/expected/sort_ci_ilu.robot
@@ -1,0 +1,19 @@
+*** Keywords ***
+my another keyword
+    Log Many    123
+    ...
+    # Comment
+
+
+My Keyword
+    Kw1
+    Kw3
+        one more kw
+_my secrete keyword
+    Log    123
+
+my_another_cool_keyword
+
+_my_another_secrete_keyword
+    Log    123
+

--- a/tests/atest/transformers/SmartSortKeywords/expected/sort_ci_ilu_iou.robot
+++ b/tests/atest/transformers/SmartSortKeywords/expected/sort_ci_ilu_iou.robot
@@ -1,0 +1,19 @@
+*** Keywords ***
+my_another_cool_keyword
+
+
+my another keyword
+    Log Many    123
+    ...
+    # Comment
+_my_another_secrete_keyword
+    Log    123
+
+My Keyword
+    Kw1
+    Kw3
+        one more kw
+
+_my secrete keyword
+    Log    123
+

--- a/tests/atest/transformers/SmartSortKeywords/expected/sort_ci_iou.robot
+++ b/tests/atest/transformers/SmartSortKeywords/expected/sort_ci_iou.robot
@@ -1,0 +1,19 @@
+*** Keywords ***
+my_another_cool_keyword
+
+
+my another keyword
+    Log Many    123
+    ...
+    # Comment
+My Keyword
+    Kw1
+    Kw3
+        one more kw
+
+_my_another_secrete_keyword
+    Log    123
+
+_my secrete keyword
+    Log    123
+

--- a/tests/atest/transformers/SmartSortKeywords/expected/sort_ilu.robot
+++ b/tests/atest/transformers/SmartSortKeywords/expected/sort_ilu.robot
@@ -1,0 +1,19 @@
+*** Keywords ***
+My Keyword
+    Kw1
+    Kw3
+        one more kw
+
+
+my another keyword
+    Log Many    123
+    ...
+    # Comment
+_my secrete keyword
+    Log    123
+
+my_another_cool_keyword
+
+_my_another_secrete_keyword
+    Log    123
+

--- a/tests/atest/transformers/SmartSortKeywords/expected/sort_ilu_iou.robot
+++ b/tests/atest/transformers/SmartSortKeywords/expected/sort_ilu_iou.robot
@@ -1,0 +1,19 @@
+*** Keywords ***
+My Keyword
+    Kw1
+    Kw3
+        one more kw
+
+
+my_another_cool_keyword
+my another keyword
+    Log Many    123
+    ...
+    # Comment
+
+_my_another_secrete_keyword
+    Log    123
+
+_my secrete keyword
+    Log    123
+

--- a/tests/atest/transformers/SmartSortKeywords/expected/sort_iou.robot
+++ b/tests/atest/transformers/SmartSortKeywords/expected/sort_iou.robot
@@ -1,0 +1,19 @@
+*** Keywords ***
+My Keyword
+    Kw1
+    Kw3
+        one more kw
+
+
+_my_another_secrete_keyword
+    Log    123
+_my secrete keyword
+    Log    123
+
+my_another_cool_keyword
+
+my another keyword
+    Log Many    123
+    ...
+    # Comment
+

--- a/tests/atest/transformers/SmartSortKeywords/source/empty_before_fist_keyword.robot
+++ b/tests/atest/transformers/SmartSortKeywords/source/empty_before_fist_keyword.robot
@@ -1,0 +1,4 @@
+*** Keywords ***
+
+# My Comment
+my_kw

--- a/tests/atest/transformers/SmartSortKeywords/source/multiple_sections.robot
+++ b/tests/atest/transformers/SmartSortKeywords/source/multiple_sections.robot
@@ -1,0 +1,27 @@
+*** Variables ***
+${MY_VAR}    123
+
+*** Keywords ***
+
+My Keyword
+    Kw1
+    Kw3
+        one more kw
+
+
+my another keyword
+    Log Many    123
+    ...
+    # Comment
+my_another_cool_keyword
+
+_my secrete keyword
+    Log    123
+
+_my_another_secrete_keyword
+    Log    123
+
+
+
+*** Settings ***
+Library    Collections

--- a/tests/atest/transformers/SmartSortKeywords/source/sort_input.robot
+++ b/tests/atest/transformers/SmartSortKeywords/source/sort_input.robot
@@ -1,0 +1,19 @@
+*** Keywords ***
+My Keyword
+    Kw1
+    Kw3
+        one more kw
+
+
+my another keyword
+    Log Many    123
+    ...
+    # Comment
+my_another_cool_keyword
+
+_my secrete keyword
+    Log    123
+
+_my_another_secrete_keyword
+    Log    123
+

--- a/tests/atest/transformers/test_transformers.py
+++ b/tests/atest/transformers/test_transformers.py
@@ -426,3 +426,17 @@ class TestSmartSortKeywords:
             expected=['sort_.robot'],
             config=":case_insensitive=False:ignore_other_underscore=False"
         )
+
+    def test_empty_section(self):
+        run_tidy_and_compare(
+            self.TRANSFORMER_NAME,
+            sources=['empty_before_fist_keyword.robot'],
+            expected=['empty_before_fist_keyword.robot']
+        )
+
+    def test_multiple_sections(self):
+        run_tidy_and_compare(
+            self.TRANSFORMER_NAME,
+            sources=['multiple_sections.robot'],
+            expected=['multiple_sections.robot']
+        )

--- a/tests/atest/transformers/test_transformers.py
+++ b/tests/atest/transformers/test_transformers.py
@@ -359,3 +359,70 @@ class TestAlignSettingsSection:
             expected=['selected_part.robot'],
             config=' --startline 9 --endline 14'
         )
+
+@patch('robotidy.app.Robotidy.save_model', new=save_tmp_model)
+class TestSmartSortKeywords:
+    TRANSFORMER_NAME = 'SmartSortKeywords'
+
+    def test_ci_sort(self):
+        run_tidy_and_compare(
+            self.TRANSFORMER_NAME,
+            sources=['sort_input.robot'],
+            expected=['sort_ci.robot'],
+            config=":ignore_other_underscore=False"
+        )
+
+    def test_ci_ilu(self):
+        run_tidy_and_compare(
+            self.TRANSFORMER_NAME,
+            sources=['sort_input.robot'],
+            expected=['sort_ci_ilu.robot'],
+            config=":ignore_leading_underscore=True:ignore_other_underscore=False"
+        )
+
+    def test_ci_iou(self):
+        run_tidy_and_compare(
+            self.TRANSFORMER_NAME,
+            sources=['sort_input.robot'],
+            expected=['sort_ci_iou.robot']
+        )
+
+    def test_ci_ilu_iou(self):
+        run_tidy_and_compare(
+            self.TRANSFORMER_NAME,
+            sources=['sort_input.robot'],
+            expected=['sort_ci_ilu_iou.robot'],
+            config=":ignore_leading_underscore=True"
+        )
+
+    def test_ilu_iou(self):
+        run_tidy_and_compare(
+            self.TRANSFORMER_NAME,
+            sources=['sort_input.robot'],
+            expected=['sort_ilu_iou.robot'],
+            config=":case_insensitive=False:ignore_leading_underscore=True"
+        )
+
+    def test_iou(self):
+        run_tidy_and_compare(
+            self.TRANSFORMER_NAME,
+            sources=['sort_input.robot'],
+            expected=['sort_iou.robot'],
+            config=":case_insensitive=False"
+        )
+
+    def test_ilu(self):
+        run_tidy_and_compare(
+            self.TRANSFORMER_NAME,
+            sources=['sort_input.robot'],
+            expected=['sort_ilu.robot'],
+            config=":case_insensitive=False:ignore_leading_underscore=True:ignore_other_underscore=False"
+        )
+
+    def test_(self):
+        run_tidy_and_compare(
+            self.TRANSFORMER_NAME,
+            sources=['sort_input.robot'],
+            expected=['sort_.robot'],
+            config=":case_insensitive=False:ignore_other_underscore=False"
+        )


### PR DESCRIPTION
New transformer that allows to sort keywords (https://github.com/MarketSquare/robotframework-tidy/issues/52) using following (default behaviour, could be changed) logic:
 - sorting is case insensitive
 - leading underscores are not ignored, but all other are treated as spaces.

For now there are 2 issues with this PR:
1. If understand correctly right now all transformers are run unless configuration file is present or transformers are selected via command line. I think it would be good to wait until https://github.com/MarketSquare/robotframework-tidy/issues/10 is resolved, so this one will be disabled by default.
2. Test `test_nested_src` is failing for me 7 times out of 8. I would appreciate if you take a look and tell me where I messed up.