### PR TITLE
Add SeparatorNormalizer transformer

### DIFF
--- a/robotidy/cli.py
+++ b/robotidy/cli.py
@@ -248,13 +248,6 @@ def get_paths(src: Tuple[str, ...]):
     show_default=True
 )
 @click.option(
-    '-p',
-    '--usepipes',
-    is_flag=True,
-    help="Use pipe ('|') as a column separator in the plain text format.",
-    show_default=True
-)
-@click.option(
     '-sl',
     '--startline',
     default=None,
@@ -315,7 +308,6 @@ def cli(
         check: bool,
         spacecount: int,
         lineseparator: str,
-        usepipes: bool,
         verbose: bool,
         config: Optional[str],
         startline: Optional[int],
@@ -343,7 +335,6 @@ def cli(
         click.echo(f'Loaded {config} configuration file')
 
     formatting_config = GlobalFormattingConfig(
-        use_pipes=usepipes,
         space_count=spacecount,
         line_sep=lineseparator,
         start_line=startline,

--- a/robotidy/decorators.py
+++ b/robotidy/decorators.py
@@ -13,6 +13,8 @@ def check_start_end_line(func):
     """
     @functools.wraps(func)
     def wrapper(self, node):
+        if not node:
+            return return_node_untouched(node)
         if not node_within_lines(
                 node.lineno,
                 node.end_lineno,

--- a/robotidy/transformers/RemoveEmptySettings.py
+++ b/robotidy/transformers/RemoveEmptySettings.py
@@ -5,7 +5,7 @@ from robot.api.parsing import (
     ModelTransformer,
     Token
 )
-from robot.parsing.model.statements import Statement
+
 from robotidy.decorators import check_start_end_line
 
 

--- a/robotidy/transformers/SeparatorNormalizer.py
+++ b/robotidy/transformers/SeparatorNormalizer.py
@@ -1,0 +1,91 @@
+from itertools import takewhile
+
+from robot.api.parsing import (
+    ModelTransformer,
+    Token
+)
+
+from robotidy.decorators import check_start_end_line
+
+
+class SeparatorNormalizer(ModelTransformer):
+    """
+    Normalize separators and indents.
+
+    All separators (pipes included) are converted to fixed length of 4 spaces (configurable via global argument
+    ``--spacecount``).
+
+    Supports global formatting params: ``--startline`` and ``--endline``.
+    """
+    def __init__(self):
+        self.indent = 0
+
+    def visit_File(self, node):  # noqa
+        self.indent = 0
+        return self.generic_visit(node)
+
+    def visit_TestCase(self, node):  # noqa
+        self.visit_Statement(node.header)
+        self.indent += 1
+        node.body = [self.visit(item) for item in node.body]
+        self.indent -= 1
+        return node
+
+    def visit_Keyword(self, node):  # noqa
+        self.visit_Statement(node.header)
+        self.indent += 1
+        node.body = [self.visit(item) for item in node.body]
+        self.indent -= 1
+        return node
+
+    def visit_For(self, node):
+        self.visit_Statement(node.header)
+        self.indent += 1
+        node.body = [self.visit(item) for item in node.body]
+        self.indent -= 1
+        self.visit_Statement(node.end)
+        return node
+
+    def visit_If(self, node):
+        self.visit_Statement(node.header)
+        self.indent += 1
+        node.body = [self.visit(item) for item in node.body]
+        self.indent -= 1
+        if node.orelse:
+            self.visit(node.orelse)
+        if node.end:
+            self.visit_Statement(node.end)
+        return node
+
+    @check_start_end_line
+    def visit_Statement(self, statement):  # noqa
+        has_pipes = statement.tokens[0].value.startswith('|')
+        return self._handle_spaces(statement, has_pipes)
+
+    def _handle_spaces(self, statement, has_pipes):
+        new_tokens = []
+        for line in statement.lines:
+            if has_pipes and len(line) > 1:
+                line = self._remove_consecutive_separators(line)
+            new_tokens.extend([self._normalize_spaces(i, t, len(line))
+                               for i, t in enumerate(line)])
+        statement.tokens = new_tokens
+        self.generic_visit(statement)
+        return statement
+
+    @staticmethod
+    def _remove_consecutive_separators(line):
+        sep_count = len(list(
+            takewhile(lambda t: t.type == Token.SEPARATOR, line)
+        ))
+        return line[sep_count - 1:]
+
+    def _normalize_spaces(self, index, token, line_length):
+        if token.type == Token.SEPARATOR:
+            spaces = self.formatting_config.space_count * self.indent \
+                if index == 0 else self.formatting_config.space_count
+            token.value = ' ' * spaces
+        # remove trailing whitespace from last token
+        if index == line_length - 2:
+            token.value = token.value.rstrip()
+        return token

--- a/robotidy/transformers/__init__.py
+++ b/robotidy/transformers/__init__.py
@@ -12,6 +12,7 @@ from robot.utils.importer import Importer
 
 
 TRANSFORMERS = [
+    'SeparatorNormalizer',
     'DiscardEmptySections',
     'MergeAndOrderSections',
     'RemoveEmptySettings',

--- a/robotidy/utils.py
+++ b/robotidy/utils.py
@@ -26,8 +26,7 @@ class StatementLinesCollector(ModelVisitor):
 
 
 class GlobalFormattingConfig:
-    def __init__(self, use_pipes: bool, space_count: int, line_sep: str, start_line: int, end_line: int):
-        self.use_pipes = use_pipes
+    def __init__(self, space_count: int, line_sep: str, start_line: int, end_line: int):
         self.space_count = space_count
         self.start_line = start_line
         self.end_line = end_line

--- a/tests/atest/transformers/SeparatorNormalizer/expected/pipes.robot
+++ b/tests/atest/transformers/SeparatorNormalizer/expected/pipes.robot
@@ -1,0 +1,58 @@
+This data is ignored at runtime but should be preserved by Tidy.
+
+*** Settings ***
+Library    MyLibrary    argument    WITH NAME    My Alias    # My library comment
+Variables    MyVariables    args    args 2    args 3    args 4    args 5    args 6
+...    args 7    args 8    args 9    args 10    args 11    args 12
+Resource    resource.robot
+
+*** Variables ***
+# standalone    comment
+${VALID}    Value
+MyVar    val1    val2    val3    val4    val5    val6    val7
+...    val8    val9    val10    # var comment
+# standalone
+
+*** Test Cases ***
+# A comment before first test
+My Test Case
+    [Documentation]    This is a documentation
+    ...    in two lines
+    My TC Step 1    my step arg    # step 1 comment
+    My TC Step 2    my step 2 arg    second \ arg    # step 2 comment
+    ...    third arg split to own row
+    ...    fourth and    fifth as well    # comment
+    [Teardown]    1 minute    args
+
+Another Test
+    Log Many    Non-ASCII: ääöö§§    ${CURDIR}
+
+*** Keyword ***
+My Keyword
+    [Documentation]    Documentation    # Comment for doc
+    [Tags]    keyword    tags
+    # Comment row
+    # Comment row 2
+    My Step 1    args    args 2    args 3    args 4    args 5    args 6
+    ...    args 7    args 8    args 9    # step 1 comment
+    FOR    ${param1}    ${param2}    IN    ${data 1}    ${data 2}    ${data 3}
+    ...    ${data 4}    ${data 5}    ${data 6}    # FOR comment
+        Loop Step    args    args 2    args 3    args 4    args 5
+        ...    args 6    args 7    args 8    args 9    # loop step comment
+        Loop Step 2
+    END
+    IF    True
+        Log    Hi!
+        FOR    ${var}    IN    one    two
+            IF    "${var}" == "one"
+                Log    ${var} is one!
+            END
+            No Operation
+        END
+    ELSE IF    False
+        Fail    Not run
+    ELSE
+        Fail    Not run
+    END
+    My Step 2    my step 2 arg    second arg    # step 2 comment
+    [Return]    args 1    args 2

--- a/tests/atest/transformers/SeparatorNormalizer/expected/test.robot
+++ b/tests/atest/transformers/SeparatorNormalizer/expected/test.robot
@@ -1,0 +1,36 @@
+*** Settings ***
+Library    library.py    WITH NAME    alias
+
+Force Tags    tag
+...    tag
+
+Documentation    doc
+...    multi
+...    line
+
+*** Test Cases ***
+Test case
+    [Setup]    Keyword
+    Keyword    with    arg
+    ...    and    multi    lines
+    [Teardown]    Keyword
+
+Test case with structures
+    FOR    ${variable}    IN    1    2
+        Keyword
+        IF    ${condition}
+            Log    ${stuff}    console=True
+        END
+    END
+
+*** Keywords ***
+Keyword
+Another Keyword
+    [Arguments]    ${arg}
+    Should Be Equal    1
+    ...    ${arg}
+    IF    ${condition}
+        FOR    ${v}    IN RANGE    10
+            Keyword
+        END
+    END

--- a/tests/atest/transformers/SeparatorNormalizer/expected/test.robot
+++ b/tests/atest/transformers/SeparatorNormalizer/expected/test.robot
@@ -34,3 +34,8 @@ Another Keyword
             Keyword
         END
     END
+
+Keyword With Tabulators
+    Keyword
+    ...    2
+    ...    ${arg}

--- a/tests/atest/transformers/SeparatorNormalizer/expected/test_8spaces.robot
+++ b/tests/atest/transformers/SeparatorNormalizer/expected/test_8spaces.robot
@@ -1,0 +1,36 @@
+*** Settings ***
+Library        library.py        WITH NAME        alias
+
+Force Tags        tag
+...        tag
+
+Documentation        doc
+...        multi
+...        line
+
+*** Test Cases ***
+Test case
+        [Setup]        Keyword
+        Keyword        with        arg
+        ...        and        multi        lines
+        [Teardown]        Keyword
+
+Test case with structures
+        FOR        ${variable}        IN        1        2
+                Keyword
+                IF        ${condition}
+                        Log        ${stuff}        console=True
+                END
+        END
+
+*** Keywords ***
+Keyword
+Another Keyword
+        [Arguments]        ${arg}
+        Should Be Equal        1
+        ...        ${arg}
+        IF        ${condition}
+                FOR        ${v}        IN RANGE        10
+                        Keyword
+                END
+        END

--- a/tests/atest/transformers/SeparatorNormalizer/expected/test_8spaces.robot
+++ b/tests/atest/transformers/SeparatorNormalizer/expected/test_8spaces.robot
@@ -34,3 +34,8 @@ Another Keyword
                         Keyword
                 END
         END
+
+Keyword With Tabulators
+        Keyword
+        ...        2
+        ...        ${arg}

--- a/tests/atest/transformers/SeparatorNormalizer/source/pipes.robot
+++ b/tests/atest/transformers/SeparatorNormalizer/source/pipes.robot
@@ -1,0 +1,58 @@
+| This data is ignored at runtime but should be preserved by Tidy. |
+
+| *** Settings *** |
+| Library        | MyLibrary | argument | WITH NAME | My Alias | # My library comment |
+| Variables      | MyVariables | args | args 2 | args 3 | args 4 | args 5 | args 6 |
+| ...            | args 7 | args 8 | args 9 | args 10 | args 11 | args 12 |
+| Resource       | resource.robot |
+|
+| *** Variables *** |
+| # standalone   | comment |
+| ${VALID}       | Value |
+| MyVar          | val1 | val2 | val3 | val4 | val5 | val6 | val7 |
+| ...            | val8 | val9 | val10 | # var comment |
+| # standalone   |
+
+| *** Test Cases *** |
+|    # A comment before first test |
+| My Test Case |
+|    | [Documentation] | This is a documentation |
+|    | ... | in two lines |
+|    | My TC Step 1 | my step arg | # step 1 comment |
+|    | My TC Step 2 | my step 2 arg | second \ arg | # step 2 comment |
+|    | ... | third arg split to own row |
+|    | ... | fourth and | fifth as well | # comment |
+|    | [Teardown] | 1 minute | args |
+
+| Another Test |
+|    | Log Many | Non-ASCII: ääöö§§ | ${CURDIR} |
+
+| *** Keyword *** |
+|    My Keyword |
+|    | [Documentation] | Documentation | # Comment for doc |
+|    | [Tags] | keyword | tags |
+|    | # Comment row |
+|    | # Comment row 2 |
+|    | My Step 1 | args | args 2 | args 3 | args 4 | args 5 | args 6 |
+|    | ... | args 7 | args 8 | args 9 | # step 1 comment |
+|    | FOR | ${param1} | ${param2} | IN | ${data 1} | ${data 2} | ${data 3} |
+|    | ... | ${data 4} | ${data 5} | ${data 6} | # FOR comment |
+|    |    | Loop Step | args | args 2 | args 3 | args 4 | args 5 |
+|    |    | ... | args 6 | args 7 | args 8 | args 9 | # loop step comment |
+|    |    | Loop Step 2 |
+|    | END |
+|    | IF | True |
+|    | | Log | Hi! |
+|    | | FOR | ${var} | IN | one | two |
+|    | | | IF | "${var}" == "one" |
+|    | | | | Log | ${var} is one! |
+|    | | | END |
+|    | | | No Operation |
+|    | | END |
+|    | ELSE IF | False |
+|    | | Fail | Not run |
+|    | ELSE |
+|    | | Fail | Not run |
+|    | END |
+|    | My Step 2 | my step 2 arg | second arg | # step 2 comment |
+|    | [Return] | args 1 | args 2 |

--- a/tests/atest/transformers/SeparatorNormalizer/source/test.robot
+++ b/tests/atest/transformers/SeparatorNormalizer/source/test.robot
@@ -34,3 +34,8 @@ Another Keyword
    Keyword
         END
    END
+
+Keyword With Tabulators
+    Keyword
+    ...  2
+	...  ${arg}

--- a/tests/atest/transformers/SeparatorNormalizer/source/test.robot
+++ b/tests/atest/transformers/SeparatorNormalizer/source/test.robot
@@ -1,0 +1,36 @@
+*** Settings ***
+Library  library.py  WITH NAME          alias
+
+Force Tags           tag
+...   tag
+
+Documentation  doc
+...      multi
+...  line
+
+*** Test Cases ***
+Test case
+  [Setup]  Keyword
+   Keyword  with  arg
+   ...  and  multi  lines
+     [Teardown]          Keyword
+
+Test case with structures
+    FOR  ${variable}  IN  1  2
+    Keyword
+     IF  ${condition}
+       Log  ${stuff}  console=True
+  END
+   END
+
+*** Keywords ***
+Keyword
+Another Keyword
+          [Arguments]  ${arg}
+       Should Be Equal  1
+       ...  ${arg}
+   IF  ${condition}
+        FOR  ${v}  IN RANGE  10
+   Keyword
+        END
+   END

--- a/tests/atest/transformers/test_transformers.py
+++ b/tests/atest/transformers/test_transformers.py
@@ -562,3 +562,21 @@ class TestRemoveEmptySettings:
             config=f'{work_mode_config}{more_explicit_config}'
         )
 
+
+@patch('robotidy.app.Robotidy.save_model', new=save_tmp_model)
+class TestSeparatorNormalizer:
+    TRANSFORMER_NAME = 'SeparatorNormalizer'
+
+    def test_normalize_separators(self):
+        run_tidy_and_compare(self.TRANSFORMER_NAME, sources=['test.robot'])
+
+    def test_normalize_with_8_spaces(self):
+        run_tidy_and_compare(
+            self.TRANSFORMER_NAME,
+            sources=['test.robot'],
+            expected=['test_8spaces.robot'],
+            config=' --spacecount 8'
+        )
+
+    def test_pipes(self):
+        run_tidy_and_compare(self.TRANSFORMER_NAME, sources=['pipes.robot'])


### PR DESCRIPTION
Closes #32 
Remove support for pipes. It was not supported anyway but there were arguments in CLI that suggested otherwise. SeparatorNormalizer will also replace all pipes to spaces.
