### PR TITLE
Print similar names when using wrong transformer name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### Features
 - New option ``--output`` option for saving transformed file to provided path instead of overwriting source file [#108](https://github.com/MarketSquare/robotframework-tidy/issues/108)
+- ``--desc`` now accepts ``all`` for printing out description of all transformers
 
 ### Fixes
 - Renamed short version of ``--lineseparator`` to ``-ls`` to avoid collision with ``--list\-l``

--- a/robotidy/cli.py
+++ b/robotidy/cli.py
@@ -16,7 +16,8 @@ from robotidy.transformers import load_transformers
 from robotidy.utils import (
     GlobalFormattingConfig,
     split_args_from_name_or_path,
-    remove_rst_formatting
+    remove_rst_formatting,
+    RecommendationFinder
 )
 from robotidy.version import __version__
 
@@ -184,7 +185,9 @@ def print_description(name: str):
         click.echo(f"Transformer {name}:")
         click.echo(remove_rst_formatting(transformer_by_names[name].__doc__))
     else:
-        click.echo(f"Transformer with the name '{name}' does not exist")
+        rec_finder = RecommendationFinder()
+        similar = rec_finder.find_similar(name, transformer_by_names.keys())
+        click.echo(f"Transformer with the name '{name}' does not exist.{similar}")
 
 
 def print_transformers_list():

--- a/robotidy/cli.py
+++ b/robotidy/cli.py
@@ -173,6 +173,27 @@ def read_config(ctx: click.Context, param: click.Parameter, value: Optional[str]
     ctx.default_map = default_map
 
 
+def print_description(name: str):
+    transformers = load_transformers(None, {})
+    transformer_by_names = {transformer.__class__.__name__: transformer for transformer in transformers}
+    if name == 'all':
+        for tr_name, transformer in transformer_by_names.items():
+            click.echo(f"Transformer {tr_name}:")
+            click.echo(remove_rst_formatting(transformer.__doc__))
+    elif name in transformer_by_names:
+        click.echo(f"Transformer {name}:")
+        click.echo(remove_rst_formatting(transformer_by_names[name].__doc__))
+    else:
+        click.echo(f"Transformer with the name '{name}' does not exist")
+
+
+def print_transformers_list():
+    transformers = load_transformers(None, {})
+    click.echo('To see detailed docs run --desc <transformer_name> or --desc all.\nAvailable transformers:\n')
+    for transformer in transformers:
+        click.echo(transformer.__class__.__name__)
+
+
 @click.command(cls=RawHelp, help=HELP_MSG, epilog=EPILOG, context_settings=CONTEXT_SETTINGS)
 @click.option(
     '--transform',
@@ -337,19 +358,10 @@ def cli(
         print('--describe-transformer is deprecated in 1.3.0. Use --desc NAME instead')
         ctx.exit(0)
     if list:
-        transformers = load_transformers(None, {})
-        click.echo('Run --desc <transformer_name> to get more details. Transformers:')
-        for transformer in transformers:
-            click.echo(transformer.__class__.__name__)
+        print_transformers_list()
         ctx.exit(0)
     if desc is not None:
-        transformers = load_transformers(None, {})
-        transformer_by_names = {transformer.__class__.__name__: transformer for transformer in transformers}
-        if desc in transformer_by_names:
-            click.echo(f"Transformer {desc}:")
-            click.echo(remove_rst_formatting(transformer_by_names[desc].__doc__))
-        else:
-            click.echo(f"Transformer with the name '{desc}' does not exist")
+        print_description(desc)
         ctx.exit(0)
     if not src:
         print("No source path provided. Run robotidy --help to see how to use robotidy")

--- a/robotidy/cli.py
+++ b/robotidy/cli.py
@@ -188,6 +188,8 @@ def print_description(name: str):
         rec_finder = RecommendationFinder()
         similar = rec_finder.find_similar(name, transformer_by_names.keys())
         click.echo(f"Transformer with the name '{name}' does not exist.{similar}")
+        return 1
+    return 0
 
 
 def print_transformers_list():
@@ -364,8 +366,8 @@ def cli(
         print_transformers_list()
         ctx.exit(0)
     if desc is not None:
-        print_description(desc)
-        ctx.exit(0)
+        return_code = print_description(desc)
+        ctx.exit(return_code)
     if not src:
         print("No source path provided. Run robotidy --help to see how to use robotidy")
         ctx.exit(0)

--- a/robotidy/transformers/__init__.py
+++ b/robotidy/transformers/__init__.py
@@ -43,12 +43,12 @@ def import_transformer(name, args):
         return Importer().import_class_or_module(name, instantiate_with_args=args)
     except DataError as err:
         if 'Creating instance failed' in str(err):
-            raise err
+            raise err from None
         short_name = name.split('.')[-1]
         similar_finder = RecommendationFinder()
         similar = similar_finder.find_similar(short_name, TRANSFORMERS)
         raise ImportTransformerError(f"Importing transformer '{short_name}' failed. "
-                                     f"Verify if correct name or configuration was provided.{similar}")
+                                     f"Verify if correct name or configuration was provided.{similar}") from None
 
 
 def load_transformers(allowed_transformers, config):

--- a/robotidy/utils.py
+++ b/robotidy/utils.py
@@ -1,8 +1,6 @@
 import os
 from typing import List
 import difflib
-from collections import defaultdict
-import re
 
 from robot.api.parsing import (
     ModelVisitor,

--- a/robotidy/utils.py
+++ b/robotidy/utils.py
@@ -1,5 +1,8 @@
 import os
 from typing import List
+import difflib
+from collections import defaultdict
+import re
 
 from robot.api.parsing import (
     ModelVisitor,
@@ -151,3 +154,49 @@ def left_align(node):
 
 def remove_rst_formatting(text):
     return text.replace('::', ':').replace("``", "'")
+
+
+class RecommendationFinder:
+    def find_similar(self, name, candidates):
+        norm_name = name.lower()
+        norm_cand = self.get_normalized_candidates(candidates)
+        matches = self.find(norm_name, norm_cand.keys())
+        if not matches:
+            return ''
+        matches = self.get_original_candidates(matches, norm_cand)
+        suggestion = ' Did you mean:\n'
+        suggestion += '\n'.join(f'    {match}' for match in matches)
+        return suggestion
+
+    def find(self, name, candidates, max_matches=2):
+        """ Return a list of close matches to `name` from `candidates`. """
+        if not name or not candidates:
+            return []
+        cutoff = self._calculate_cutoff(name)
+        return difflib.get_close_matches(
+            name, candidates, n=max_matches, cutoff=cutoff
+        )
+
+    @staticmethod
+    def _calculate_cutoff(string, min_cutoff=.5, max_cutoff=.85,
+                          step=.03):
+        """ The longer the string the bigger required cutoff. """
+        cutoff = min_cutoff + len(string) * step
+        return min(cutoff, max_cutoff)
+
+    @staticmethod
+    def get_original_candidates(candidates, norm_candidates):
+        """ Map found normalized candidates to unique original candidates. """
+        return sorted(list(set(c for cand in candidates for c in norm_candidates[cand])))
+
+    @staticmethod
+    def get_normalized_candidates(candidates):
+        norm_cand = {cand.lower(): [cand] for cand in candidates}
+        # most popular typos
+        norm_cand['align'] = ['AlignSettingsSection', 'AlignVariablesSection']
+        norm_cand['normalize'] = ['NormalizeNewLines', 'NormalizeSectionHeaderName', 'NormalizeSeparators',
+                                  'NormalizeSettingName']
+        norm_cand['order'] = ['OrderSettings', 'OrderSettingsSection']
+        norm_cand['alignsettings'] = ['AlignSettingsSection']
+        norm_cand['alignvariables'] = ['AlignVariablesSection']
+        return norm_cand

--- a/tests/utest/test_cli.py
+++ b/tests/utest/test_cli.py
@@ -14,6 +14,7 @@ from robotidy.cli import (
 )
 from robotidy.utils import node_within_lines
 from robotidy.transformers import load_transformers
+from robotidy.transformers.AlignSettingsSection import AlignSettingsSection
 from robotidy.transformers.ReplaceRunKeywordIf import ReplaceRunKeywordIf
 from robotidy.version import __version__
 
@@ -173,18 +174,26 @@ class TestCli:
 
     def test_list_transformers(self):
         result = run_tidy(['--list'])
-        assert 'Run --desc <transformer_name> to get more details. Transformers:' in result.output
+        assert 'To see detailed docs run --desc <transformer_name> or --desc all.\nAvailable transformers:\n'\
+               in result.output
         assert 'ReplaceRunKeywordIf\n' in result.output
         result = run_tidy(['-l'])
-        assert 'Run --desc <transformer_name> to get more details. Transformers:' in result.output
+        assert 'To see detailed docs run --desc <transformer_name> or --desc all.\nAvailable transformers:\n'\
+               in result.output
         assert 'ReplaceRunKeywordIf\n' in result.output
 
     def test_describe_transformer(self):
         expected_doc = ReplaceRunKeywordIf.__doc__.replace('::', ':').replace("``", "'")
+        expected_doc2 = AlignSettingsSection.__doc__.replace('::', ':').replace("``", "'")
         result = run_tidy(['--desc', 'ReplaceRunKeywordIf'])
         assert expected_doc in result.output
+        assert expected_doc2 not in result.output
         result = run_tidy(['-d', 'ReplaceRunKeywordIf'])
         assert expected_doc in result.output
+        assert expected_doc2 not in result.output
+        result = run_tidy(['--desc', 'all'])
+        assert expected_doc in result.output
+        assert expected_doc2 in result.output
 
     def test_help(self):
         result = run_tidy(['--help'])

--- a/tests/utest/test_cli.py
+++ b/tests/utest/test_cli.py
@@ -29,9 +29,16 @@ class TestCli:
         """ It should recursively search and find `testdata/test.robot` file """
         run_tidy(src)
 
-    def test_not_existing_transformer(self):
-        expected_output = "Importing 'NotExisting' failed: ModuleNotFoundError: No module named 'NotExisting'"
-        args = '--transform NotExisting --transform MissingTransformer --transform DiscardEmptySections -'.split()
+    @pytest.mark.parametrize('name, similar', [
+        ('NotExisting', ''),
+        ('AlignSettings', ' Did you mean:\n    AlignSettingsSection'),
+        ('align', ' Did you mean:\n    AlignSettingsSection\n    AlignVariablesSection'),
+        ('splittoolongline', ' Did you mean:\n    SplitTooLongLine')
+    ])
+    def test_not_existing_transformer(self, name, similar):
+        expected_output = f"Importing transformer '{name}' failed. " \
+                          f"Verify if correct name or configuration was provided.{similar}"
+        args = f'--transform {name} --transform MissingTransformer --transform DiscardEmptySections -'.split()
         result = run_tidy(args, exit_code=1)
         assert expected_output in str(result.exception)
 
@@ -46,8 +53,8 @@ class TestCli:
     #     assert expected_output == result.output
 
     def test_invalid_configurable_usage(self):
-        expected_output = "Importing 'DiscardEmptySections=allow_only_comments=False' failed: " \
-                          "ModuleNotFoundError: No module named 'DiscardEmptySections=allow_only_comments=False'"
+        expected_output = "Importing transformer 'DiscardEmptySections=allow_only_comments=False' failed. " \
+                          "Verify if correct name or configuration was provided"
         args = '--transform DiscardEmptySections=allow_only_comments=False -'.split()
         result = run_tidy(args, exit_code=1)
         assert expected_output in str(result.exception)


### PR DESCRIPTION
It works for --transform and --desc options hovewer it doesn't support --configure (it can be extended later). 

Closes #107 