### PR TITLE
spelling fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -85,7 +85,7 @@
 ### Transformers
 
 - DiscardEmptySections - empty sections are removed
-- SplitTooLongLine - keywords with too long lines are splitted
+- SplitTooLongLine - keywords with too long lines are split
 - NormalizeSettingName - ensure that setting names are Title Case - Test Template, Library
 - AssignmentNormalizer - use only one type of assignment
 - NormalizeNewLines - ensure proper number of empty lines between keywords, test cases and sections

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,7 +44,7 @@
 
 ### Features
 - New option ``--configure`` or ``-c`` for configuring transformer parameters. It works the same way configuring through ``--transform`` works. The benefit of using ``--configure`` is that you can configure selected transformers and still run all transformers [#96](https://github.com/MarketSquare/robotframework-tidy/issues/96)
-- Transformers can now be disabled by default if you add ``ENABLED = False`` class attribute to your class. Those transformers will be only run when selected explictly with ``--transform`` option [#10](https://github.com/MarketSquare/robotframework-tidy/issues/10)
+- Transformers can now be disabled by default if you add ``ENABLED = False`` class attribute to your class. Those transformers will be only run when selected explicitly with ``--transform`` option [#10](https://github.com/MarketSquare/robotframework-tidy/issues/10)
 - Support for ``pyproject.toml`` configuration files. Because of the required changes there are backward incompatible changes done to ``robotidy.toml`` syntax. See example from [README](https://github.com/MarketSquare/robotframework-tidy/blob/main/README.rst#configuration-file) [#66](https://github.com/MarketSquare/robotframework-tidy/issues/66)
 - ``--list-transformers`` output is now ordered. Also transformers themselves will always run in the same predefined order [#69](https://github.com/MarketSquare/robotframework-tidy/issues/69)
 - ``--describe-transformer`` output is now pre-formatted (removed rst formatting) [#83](https://github.com/MarketSquare/robotframework-tidy/issues/83)

--- a/docs/source/configuration/configuring_transformers.rst
+++ b/docs/source/configuration/configuring_transformers.rst
@@ -3,7 +3,7 @@
 Configuring Transformers
 ========================
 
-Transformers can be configured through two diffrent options: ``--transform`` and ``--configure``. They share the same
+Transformers can be configured through two different options: ``--transform`` and ``--configure``. They share the same
 syntax for parameter names and values. The main difference is that ``--transform`` is also used to select what
 transformers will be used. For example::
 

--- a/docs/source/transformers/ReplaceRunKeywordIf.rst
+++ b/docs/source/transformers/ReplaceRunKeywordIf.rst
@@ -45,7 +45,7 @@ Any return value will be applied to every ELSE/ELSE IF branch.
             ${var}    Keyword2
         END
 
-Run Keywords inside Run Keyword If will be splitted into separate keywords.
+Run Keywords inside Run Keyword If will be split into separate keywords.
 
 .. tabs::
 

--- a/docs/source/transformers/SmartSortKeywords.rst
+++ b/docs/source/transformers/SmartSortKeywords.rst
@@ -9,7 +9,7 @@ SmartSortKeywords is not included in default transformers that's why you need to
 
     robotidy --transform SmartSortKeywords src
 
-By default sorting is case insensitve, but keywords with leading underscore go to the bottom. Other underscores are
+By default sorting is case insensitive, but keywords with leading underscore go to the bottom. Other underscores are
 treated as spaces.
 Empty lines (or lack of them) between keywords are preserved.
 

--- a/robotidy/cli.py
+++ b/robotidy/cli.py
@@ -190,7 +190,7 @@ def print_description(name: str):
 def print_transformers_list():
     transformers = load_transformers(None, {}, allow_disabled=True)
     click.echo('To see detailed docs run --desc <transformer_name> or --desc all. '
-               'Transformers with (disabled) tag \nare executed only when selected explictly with --transform. '
+               'Transformers with (disabled) tag \nare executed only when selected explicitly with --transform. '
                'Available transformers:\n')
     transformer_names = []
     for transformer in transformers:

--- a/robotidy/transformers/MergeAndOrderSections.py
+++ b/robotidy/transformers/MergeAndOrderSections.py
@@ -56,7 +56,7 @@ class MergeAndOrderSections(ModelTransformer):
         )
         if not order:
             return default_order
-        splitted = order.lower().split(',')
+        parts = order.lower().split(',')
         map = {
             'comments': Token.COMMENT_HEADER,
             'comment': Token.COMMENT_HEADER,
@@ -70,8 +70,8 @@ class MergeAndOrderSections(ModelTransformer):
             'keyword': Token.KEYWORD_HEADER
         }
         parsed_order = []
-        for split in splitted:
-            parsed_order.append(map.get(split, None))
+        for part in parts:
+            parsed_order.append(map.get(part, None))
         if any(header not in parsed_order for header in default_order) and len(parsed_order) != len(default_order):
             raise click.BadOptionUsage(
                 option_name='transform',

--- a/robotidy/transformers/NormalizeSeparators.py
+++ b/robotidy/transformers/NormalizeSeparators.py
@@ -38,19 +38,19 @@ class NormalizeSeparators(ModelTransformer):
             return default
         if not sections:
             return {}
-        splitted = sections.split(',')
+        parts = sections.split(',')
         parsed_sections = set()
-        for split in splitted:
-            split = split.replace('_', '')
-            if split and split[-1] != 's':
-                split += 's'
-            if split not in default:
+        for part in parts:
+            part = part.replace('_', '')
+            if part and part[-1] != 's':
+                part += 's'
+            if part not in default:
                 raise click.BadOptionUsage(
                     option_name='transform',
                     message=f"Invalid configurable value: '{sections}' for sections for NormalizeSeparators transformer."
                             f" Sections to be transformed should be provided in comma separated list with valid section"
                             f" names:\n{sorted(default)}")
-            parsed_sections.add(split)
+            parsed_sections.add(part)
         return parsed_sections
 
     def visit_File(self, node):  # noqa

--- a/robotidy/transformers/OrderSettings.py
+++ b/robotidy/transformers/OrderSettings.py
@@ -78,9 +78,9 @@ class OrderSettings(ModelTransformer):
             return default
         if not order:
             return []
-        splitted = order.lower().split(',')
+        parts = order.lower().split(',')
         try:
-            return [name_map[split] for split in splitted]
+            return [name_map[part] for part in parts]
         except KeyError:
             raise click.BadOptionUsage(
                 option_name='transform',

--- a/robotidy/transformers/OrderSettingsSection.py
+++ b/robotidy/transformers/OrderSettingsSection.py
@@ -108,14 +108,14 @@ class OrderSettingsSection(ModelTransformer):
             return default
         if not order:
             return []
-        splitted = order.lower().split(',')
-        if any(split not in default for split in splitted):
+        parts = order.lower().split(',')
+        if any(part not in default for part in parts):
             raise click.BadOptionUsage(
                 option_name='transform',
                 message=f"Invalid configurable value: '{order}' for group_order for OrderSettingsSection transformer."
                         f" Custom order should be provided in comma separated list with valid group names:\n{default}"
             )
-        return splitted
+        return parts
 
     @staticmethod
     def parse_order_in_group(order, default, mapping):
@@ -123,9 +123,9 @@ class OrderSettingsSection(ModelTransformer):
             return default
         if not order:
             return []
-        splitted = order.lower().split(',')
+        parts = order.lower().split(',')
         try:
-            return [mapping[split] for split in splitted]
+            return [mapping[part] for part in parts]
         except KeyError:
             raise click.BadOptionUsage(
                 option_name='transform',

--- a/robotidy/transformers/ReplaceRunKeywordIf.py
+++ b/robotidy/transformers/ReplaceRunKeywordIf.py
@@ -87,7 +87,7 @@ class ReplaceRunKeywordIf(ModelTransformer):
             Token(Token.EOL)
         ])
         prev_if = None
-        for branch in reversed(list(self.split_args_on_delimeters(raw_args, ('ELSE', 'ELSE IF'), assign=assign))):
+        for branch in reversed(list(self.split_args_on_delimiters(raw_args, ('ELSE', 'ELSE IF'), assign=assign))):
             if branch[0].value == 'ELSE':
                 header = ElseHeader([
                     separator,
@@ -128,7 +128,7 @@ class ReplaceRunKeywordIf(ModelTransformer):
     def create_keywords(self, arg_tokens, assign, indent):
         if normalize_name(arg_tokens[0].value) == 'runkeywords':
             return [self.args_to_keyword(keyword[1:], assign, indent)
-                    for keyword in self.split_args_on_delimeters(arg_tokens, ('AND',))]
+                    for keyword in self.split_args_on_delimiters(arg_tokens, ('AND',))]
         return self.args_to_keyword(arg_tokens, assign, indent)
 
     def args_to_keyword(self, arg_tokens, assign, indent):
@@ -140,7 +140,7 @@ class ReplaceRunKeywordIf(ModelTransformer):
         return KeywordCall.from_tokens(separated_tokens)
 
     @staticmethod
-    def split_args_on_delimeters(args, delimiters, assign=None):
+    def split_args_on_delimiters(args, delimiters, assign=None):
         split_points = [index for index, arg in enumerate(args) if arg.value in delimiters]
         prev_index = 0
         for split_point in split_points:

--- a/robotidy/transformers/ReplaceRunKeywordIf.py
+++ b/robotidy/transformers/ReplaceRunKeywordIf.py
@@ -140,13 +140,13 @@ class ReplaceRunKeywordIf(ModelTransformer):
         return KeywordCall.from_tokens(separated_tokens)
 
     @staticmethod
-    def split_args_on_delimeters(args, delimeters, assign=None):
-        split_points = [index for index, arg in enumerate(args) if arg.value in delimeters]
+    def split_args_on_delimeters(args, delimiters, assign=None):
+        split_points = [index for index, arg in enumerate(args) if arg.value in delimiters]
         prev_index = 0
         for split_point in split_points:
             yield args[prev_index:split_point]
             prev_index = split_point
         yield args[prev_index:len(args)]
-        if assign and 'ELSE' in delimeters and not any(arg.value == 'ELSE' for arg in args):
+        if assign and 'ELSE' in delimiters and not any(arg.value == 'ELSE' for arg in args):
             values = [Token(Token.ARGUMENT, '${None}')] * len(assign)
             yield [Token(Token.ELSE), Token(Token.ARGUMENT, 'Set Variable'), *values]

--- a/robotidy/transformers/ReplaceRunKeywordIf.py
+++ b/robotidy/transformers/ReplaceRunKeywordIf.py
@@ -54,7 +54,7 @@ class ReplaceRunKeywordIf(ModelTransformer):
             ${var}    Keyword2
         END
 
-    Run Keywords inside Run Keyword If will be splitted into separate keywords::
+    Run Keywords inside Run Keyword If will be split into separate keywords::
 
        Run Keyword If  ${condition}  Run Keywords  Keyword  ${arg}  AND  Keyword2
 

--- a/robotidy/transformers/SmartSortKeywords.py
+++ b/robotidy/transformers/SmartSortKeywords.py
@@ -6,7 +6,7 @@ class SmartSortKeywords(ModelTransformer):
     """
     Sort keywords in *** Keywords *** section.
 
-    By default sorting is case insensitve, but keywords with leading underscore go to the bottom. Other underscores are
+    By default sorting is case insensitive, but keywords with leading underscore go to the bottom. Other underscores are
     treated as spaces.
     Empty lines (or lack of them) between keywords are preserved.
 

--- a/tests/atest/transformers/OrderSettings/expected/custom_order_all_end.robot
+++ b/tests/atest/transformers/OrderSettings/expected/custom_order_all_end.robot
@@ -79,4 +79,4 @@ Return first and comment last
     [Return]  stuff
     # I want to be here
 
-# what will happend with me?
+# what will happen with me?

--- a/tests/atest/transformers/OrderSettings/expected/custom_order_default.robot
+++ b/tests/atest/transformers/OrderSettings/expected/custom_order_default.robot
@@ -79,4 +79,4 @@ Return first and comment last
     [Return]  stuff
     # I want to be here
 
-# what will happend with me?
+# what will happen with me?

--- a/tests/atest/transformers/OrderSettings/expected/custom_order_without_test_teardown.robot
+++ b/tests/atest/transformers/OrderSettings/expected/custom_order_without_test_teardown.robot
@@ -79,4 +79,4 @@ Return first and comment last
     [Return]  stuff
     # I want to be here
 
-# what will happend with me?
+# what will happen with me?

--- a/tests/atest/transformers/OrderSettings/expected/test.robot
+++ b/tests/atest/transformers/OrderSettings/expected/test.robot
@@ -79,4 +79,4 @@ Return first and comment last
     [Return]  stuff
     # I want to be here
 
-# what will happend with me?
+# what will happen with me?

--- a/tests/atest/transformers/OrderSettings/source/test.robot
+++ b/tests/atest/transformers/OrderSettings/source/test.robot
@@ -79,4 +79,4 @@ Return first and comment last
     Keyword
     # I want to be here
 
-# what will happend with me?
+# what will happen with me?

--- a/tests/atest/transformers/SplitTooLongLine/expected/feed_until_line_length.robot
+++ b/tests/atest/transformers/SplitTooLongLine/expected/feed_until_line_length.robot
@@ -17,10 +17,10 @@ Different keyword calls
     ...    a # comment
 
     # comment
-    This is a keyword    these    arguments    wont    fit    with    that
+    This is a keyword    these    arguments    won't    fit    with    that
 
     # comment
-    This is a keyword    these    arguments    wont    fit    with    or
+    This is a keyword    these    arguments    won't    fit    with    or
     ...    without    that
 
     # Edge case here →→→→→→→→→→→→→→→→                                    HERE
@@ -86,10 +86,10 @@ For loop
         ...    a # comment
 
         # comment
-        This is a keyword    these    arguments    wont    fit    with    that
+        This is a keyword    these    arguments    won't    fit    with    that
 
         # comment
-        This is a keyword    these    arguments    wont    fit    with    or
+        This is a keyword    these    arguments    won't    fit    with    or
         ...    without    that
 
         # Edge case here →→→→→→→→→→→→→→→→                                    HERE

--- a/tests/atest/transformers/SplitTooLongLine/expected/split_on_every_arg.robot
+++ b/tests/atest/transformers/SplitTooLongLine/expected/split_on_every_arg.robot
@@ -31,7 +31,7 @@ Different keyword calls
     This is a keyword
     ...    these
     ...    arguments
-    ...    wont
+    ...    won't
     ...    fit
     ...    with
     ...    that
@@ -40,7 +40,7 @@ Different keyword calls
     This is a keyword
     ...    these
     ...    arguments
-    ...    wont
+    ...    won't
     ...    fit
     ...    with
     ...    or
@@ -154,7 +154,7 @@ For loop
         This is a keyword
         ...    these
         ...    arguments
-        ...    wont
+        ...    won't
         ...    fit
         ...    with
         ...    that
@@ -163,7 +163,7 @@ For loop
         This is a keyword
         ...    these
         ...    arguments
-        ...    wont
+        ...    won't
         ...    fit
         ...    with
         ...    or

--- a/tests/atest/transformers/SplitTooLongLine/source/tests.robot
+++ b/tests/atest/transformers/SplitTooLongLine/source/tests.robot
@@ -13,9 +13,9 @@ Different keyword calls
 
     This is a keyword     this    last    argument    is    not    really    a # comment
 
-    This is a keyword     these    arguments    wont    fit    with     that   # comment
+    This is a keyword     these    arguments    won't    fit    with     that   # comment
 
-    This is a keyword     these    arguments    wont    fit    with    or    without    that   # comment
+    This is a keyword     these    arguments    won't    fit    with    or    without    that   # comment
 
     This is a keyword     these     args    have    an    interesting
     ...  # Edge case here →→→→→→→→→→→→→→→→                                    HERE
@@ -72,9 +72,9 @@ For loop
 
         This is a keyword     this    last    argument    is    not    really    a # comment
 
-        This is a keyword     these    arguments    wont    fit    with     that   # comment
+        This is a keyword     these    arguments    won't    fit    with     that   # comment
 
-        This is a keyword     these    arguments    wont    fit    with    or    without    that   # comment
+        This is a keyword     these    arguments    won't    fit    with    or    without    that   # comment
 
         This is a keyword     these     args    have    an    interesting
         ...  # Edge case here →→→→→→→→→→→→→→→→                                    HERE

--- a/tests/utest/test_cli.py
+++ b/tests/utest/test_cli.py
@@ -198,7 +198,7 @@ class TestCli:
     def test_list_transformers(self, flag):
         result = run_tidy([flag])
         assert 'To see detailed docs run --desc <transformer_name> or --desc all. Transformers with (disabled) tag \n' \
-               'are executed only when selected explictly with --transform. Available transformers:\n'\
+               'are executed only when selected explicitly with --transform. Available transformers:\n'\
                in result.output
         assert 'ReplaceRunKeywordIf\n' in result.output
         assert 'SmartSortKeywords (disabled)\n' in result.output  # this transformer is disabled by default


### PR DESCRIPTION
Spelling issues found and resolved by [codespell ](https://github.com/codespell-project/codespell) tool. 
There is one more change suggested:
splitted -> split,
but as 'split' is already used along 'splitted' multiple times I did not resolve this in this PR.