### PR TITLE
Improve naming handling in RenameKeywords

### DIFF
--- a/robotidy/transformers/RenameKeywords.py
+++ b/robotidy/transformers/RenameKeywords.py
@@ -56,24 +56,20 @@ class RenameKeywords(ModelTransformer):
     @check_start_end_line
     def rename_node(self, node, type_of_name):
         token = node.get_token(type_of_name)
-        if not token:
+        if not token or not token.value:
             return node
-        value = token.value
-        library = ''
-        if not value:
-            return node
-        if isinstance(node, KeywordCall) and '.' in value:
-            library, value = token.value.rsplit('.', maxsplit=1)
-        if self.replace_pattern is not None:
-            value = self.replace_pattern.sub(repl=self.replace_to, string=value)
-        if self.remove_underscores and value != '_':
-            value = value.replace('_', ' ')
-            value = re.sub(r'\s{2,}', ' ', value)  # replace two or more spaces by one
-        value = "".join([a if a.isupper() else b for a, b in zip(value, string.capwords(value.strip()))])
-        if library:
-            token.value = f'{library}.{value}'
-        else:
-            token.value = value
+        values = []
+        for value in token.value.split('.'):
+            if isinstance(node, KeywordCall) and '.' in value:
+                library, value = token.value.rsplit('.', maxsplit=1)
+            if self.replace_pattern is not None:
+                value = self.replace_pattern.sub(repl=self.replace_to, string=value)
+            if self.remove_underscores and value != '_':
+                value = value.replace('_', ' ')
+                value = re.sub(r'\s{2,}', ' ', value)  # replace two or more spaces by one
+            value = "".join([a if a.isupper() else b for a, b in zip(value, string.capwords(value.strip()))])
+            values.append(value)
+        token.value = '.'.join(values)
         return node
 
     def visit_KeywordName(self, node):  # noqa

--- a/robotidy/transformers/RenameKeywords.py
+++ b/robotidy/transformers/RenameKeywords.py
@@ -69,7 +69,7 @@ class RenameKeywords(ModelTransformer):
         if self.remove_underscores and value != '_':
             value = value.replace('_', ' ')
             value = re.sub(r'\s{2,}', ' ', value)  # replace two or more spaces by one
-        value = string.capwords(value.strip())
+        value = "".join([a if a.isupper() else b for a, b in zip(value, string.capwords(value.strip()))])
         if library:
             token.value = f'{library}.{value}'
         else:

--- a/robotidy/transformers/RenameKeywords.py
+++ b/robotidy/transformers/RenameKeywords.py
@@ -3,7 +3,7 @@ from typing import Optional
 import string
 
 import click
-from robot.api.parsing import ModelTransformer, Token
+from robot.api.parsing import ModelTransformer, Token, KeywordCall
 
 from robotidy.decorators import check_start_end_line
 
@@ -58,13 +58,22 @@ class RenameKeywords(ModelTransformer):
         token = node.get_token(type_of_name)
         if not token:
             return node
-        if token.value:
-            if self.replace_pattern is not None:
-                token.value = self.replace_pattern.sub(repl=self.replace_to, string=token.value)
-            if self.remove_underscores and token.value != '_':
-                token.value = token.value.replace('_', ' ')
-                token.value = re.sub(r'\s{2,}', ' ', token.value)  # replace two or more spaces by one
-            token.value = string.capwords(token.value.strip())
+        value = token.value
+        library = ''
+        if not value:
+            return node
+        if isinstance(node, KeywordCall) and '.' in value:
+            library, value = token.value.rsplit('.', maxsplit=1)
+        if self.replace_pattern is not None:
+            value = self.replace_pattern.sub(repl=self.replace_to, string=value)
+        if self.remove_underscores and value != '_':
+            value = value.replace('_', ' ')
+            value = re.sub(r'\s{2,}', ' ', value)  # replace two or more spaces by one
+        value = string.capwords(value.strip())
+        if library:
+            token.value = f'{library}.{value}'
+        else:
+            token.value = value
         return node
 
     def visit_KeywordName(self, node):  # noqa

--- a/tests/atest/transformers/RenameKeywords/expected/rename_pattern_partial.robot
+++ b/tests/atest/transformers/RenameKeywords/expected/rename_pattern_partial.robot
@@ -40,3 +40,7 @@ Structures
 
 Double Underscores
     No Operation
+
+All Upper Case
+    Connect To System ABC
+    Create Product DFG

--- a/tests/atest/transformers/RenameKeywords/expected/rename_pattern_whole.robot
+++ b/tests/atest/transformers/RenameKeywords/expected/rename_pattern_whole.robot
@@ -40,3 +40,7 @@ Structures
 
 Double Underscores
     No Operation
+
+All Upper Case
+    Connect To System ABC
+    Create Product DFG

--- a/tests/atest/transformers/RenameKeywords/expected/test.robot
+++ b/tests/atest/transformers/RenameKeywords/expected/test.robot
@@ -40,3 +40,7 @@ Structures
 
 Double Underscores
     No Operation
+
+All Upper Case
+    Connect To System ABC
+    Create Product DFG

--- a/tests/atest/transformers/RenameKeywords/expected/with_library_name.robot
+++ b/tests/atest/transformers/RenameKeywords/expected/with_library_name.robot
@@ -1,4 +1,6 @@
 *** Keywords ***
 Library Name
     Process.Only Keyword Name
-    RPA.Browser.Playwright.Take Screenshot
+    RPA.Browser.playwright.Take Screenshot
+    SeleniumLibrary.Open Browser
+    SSHLibrary.Open Connection Host

--- a/tests/atest/transformers/RenameKeywords/expected/with_library_name.robot
+++ b/tests/atest/transformers/RenameKeywords/expected/with_library_name.robot
@@ -1,6 +1,6 @@
 *** Keywords ***
 Library Name
     Process.Only Keyword Name
-    RPA.Browser.playwright.Take Screenshot
+    RPA.Browser.Playwright.Take Screenshot
     SeleniumLibrary.Open Browser
     SSHLibrary.Open Connection Host

--- a/tests/atest/transformers/RenameKeywords/expected/with_library_name.robot
+++ b/tests/atest/transformers/RenameKeywords/expected/with_library_name.robot
@@ -1,0 +1,4 @@
+*** Keywords ***
+Library Name
+    Process.Only Keyword Name
+    RPA.Browser.Playwright.Take Screenshot

--- a/tests/atest/transformers/RenameKeywords/expected/with_underscores.robot
+++ b/tests/atest/transformers/RenameKeywords/expected/with_underscores.robot
@@ -40,3 +40,7 @@ Structures
 
 Double__underscores
     No Operation
+
+All Upper Case
+    Connect To System ABC
+    Create Product DFG

--- a/tests/atest/transformers/RenameKeywords/source/test.robot
+++ b/tests/atest/transformers/RenameKeywords/source/test.robot
@@ -38,5 +38,9 @@ Structures
             keyword
     END
 
-Double__Underscores
+Double__underscores
     No Operation
+
+All Upper Case
+    Connect To System ABC
+    Create Product DFG

--- a/tests/atest/transformers/RenameKeywords/source/with_library_name.robot
+++ b/tests/atest/transformers/RenameKeywords/source/with_library_name.robot
@@ -1,4 +1,6 @@
 *** Keywords ***
 Library Name
     Process.only keyword name
-    RPA.Browser.Playwright.Take Screenshot
+    RPA.Browser.playwright.Take Screenshot
+    SeleniumLibrary.Open Browser
+    SSHLibrary.Open Connection host

--- a/tests/atest/transformers/RenameKeywords/source/with_library_name.robot
+++ b/tests/atest/transformers/RenameKeywords/source/with_library_name.robot
@@ -1,0 +1,4 @@
+*** Keywords ***
+Library Name
+    Process.only keyword name
+    RPA.Browser.Playwright.Take Screenshot

--- a/tests/atest/transformers/RenameKeywords/test_transformer.py
+++ b/tests/atest/transformers/RenameKeywords/test_transformer.py
@@ -43,3 +43,6 @@ class TestRenameKeywords:
                           rf"'[\911]' for replace_pattern in {self.TRANSFORMER_NAME} transformer. " \
                           "It should be a valid regex expression. Regex error: 'bad escape \\9'"
         assert expected_output in str(result.exception)
+
+    def test_with_library_name(self):
+        run_tidy_and_compare(self.TRANSFORMER_NAME, source='with_library_name.robot')


### PR DESCRIPTION
Library part (after before last '.' in name) should now be ignored.
Uppercase only first letter of each word:
   Connect to ABC -> Connect To ABC (instead of Connect To Abc)

Related #199 