### PR TITLE
Fix OrderSettings transformer with inline comment

### DIFF
--- a/robotidy/transformers/OrderSettings.py
+++ b/robotidy/transformers/OrderSettings.py
@@ -144,8 +144,11 @@ class OrderSettings(ModelTransformer):
         after_seen = False
         # when after_seen is set to True then all statements go to trailing_after and last non data
         # will be appended after tokens defined in `after` set (like [Return])
+        comment = []
         for child in node.body:
-            if getattr(child, "type", "invalid") in setting_types:
+            if isinstance(child, Comment) and child.lineno == node.lineno:
+                comment.append(child)
+            elif getattr(child, "type", "invalid") in setting_types:
                 after_seen = after_seen or child.type in after
                 settings[child.type] = child
             elif after_seen:
@@ -158,7 +161,7 @@ class OrderSettings(ModelTransformer):
             trailing_non_data.insert(0, trailing_after.pop())
         not_settings += trailing_after
         node.body = (
-            self.add_in_order(before, settings) + not_settings + self.add_in_order(after, settings) + trailing_non_data
+            comment + self.add_in_order(before, settings) + not_settings + self.add_in_order(after, settings) + trailing_non_data
         )
         return node
 

--- a/tests/atest/transformers/OrderSettings/expected/custom_order_all_end.robot
+++ b/tests/atest/transformers/OrderSettings/expected/custom_order_all_end.robot
@@ -32,6 +32,15 @@ Test case 4
    Keyword3
    [Teardown]  teardown
 
+Test case 5  # comment1
+   Keyword1
+   # comment2
+   Keyword2
+   # comment3
+   Keyword3
+   [Documentation]  this is
+   [Teardown]  teardown
+
 *** Keywords ***
 Keyword
     Keyword
@@ -78,5 +87,9 @@ Return first and comment last
     Keyword
     [Return]  stuff
     # I want to be here
+
+Comment on the same line  # comment
+    [Documentation]  this is
+    ...    doc
 
 # what will happen with me?

--- a/tests/atest/transformers/OrderSettings/expected/custom_order_default.robot
+++ b/tests/atest/transformers/OrderSettings/expected/custom_order_default.robot
@@ -32,6 +32,15 @@ Test case 4
    Keyword3
    [Teardown]  teardown
 
+Test case 5  # comment1
+   [Documentation]  this is
+   Keyword1
+   # comment2
+   Keyword2
+   # comment3
+   Keyword3
+   [Teardown]  teardown
+
 *** Keywords ***
 Keyword
     [Documentation]  this is
@@ -78,5 +87,9 @@ Return first and comment last
     Keyword
     [Return]  stuff
     # I want to be here
+
+Comment on the same line  # comment
+    [Documentation]  this is
+    ...    doc
 
 # what will happen with me?

--- a/tests/atest/transformers/OrderSettings/expected/custom_order_without_test_teardown.robot
+++ b/tests/atest/transformers/OrderSettings/expected/custom_order_without_test_teardown.robot
@@ -32,6 +32,15 @@ Test case 4
    # comment2
    Keyword3
 
+Test case 5  # comment1
+   [Documentation]  this is
+   [Teardown]  teardown
+   Keyword1
+   # comment2
+   Keyword2
+   # comment3
+   Keyword3
+
 *** Keywords ***
 Keyword
     [Documentation]  this is
@@ -78,5 +87,9 @@ Return first and comment last
     Keyword
     [Return]  stuff
     # I want to be here
+
+Comment on the same line  # comment
+    [Documentation]  this is
+    ...    doc
 
 # what will happen with me?

--- a/tests/atest/transformers/OrderSettings/expected/test.robot
+++ b/tests/atest/transformers/OrderSettings/expected/test.robot
@@ -32,6 +32,15 @@ Test case 4
    Keyword3
    [Teardown]  teardown
 
+Test case 5  # comment1
+   [Documentation]  this is
+   Keyword1
+   # comment2
+   Keyword2
+   # comment3
+   Keyword3
+   [Teardown]  teardown
+
 *** Keywords ***
 Keyword
     [Documentation]  this is
@@ -78,5 +87,9 @@ Return first and comment last
     Keyword
     [Return]  stuff
     # I want to be here
+
+Comment on the same line  # comment
+    [Documentation]  this is
+    ...    doc
 
 # what will happen with me?

--- a/tests/atest/transformers/OrderSettings/source/test.robot
+++ b/tests/atest/transformers/OrderSettings/source/test.robot
@@ -32,6 +32,15 @@ Test case 4
    # comment2
    Keyword3
 
+Test case 5  # comment1
+   [Teardown]  teardown
+   [Documentation]  this is
+   Keyword1
+   # comment2
+   Keyword2
+   # comment3
+   Keyword3
+
 *** Keywords ***
 Keyword
     [Teardown]  Keyword
@@ -78,5 +87,9 @@ Return first and comment last
     [Return]  stuff
     Keyword
     # I want to be here
+
+Comment on the same line  # comment
+    [Documentation]  this is
+    ...    doc
 
 # what will happen with me?


### PR DESCRIPTION
This patch fixes a bug with the OrderSettings transformer where if a
test case/keyword has a comment on the same line the output would be
incorrect, e.g. given this input

```robot
Test case  # comment1
   [Teardown]  teardown
   [Documentation]  this is
   Keyword1
   # comment2
   Keyword2
   # comment3
   Keyword3
```

The expected output is:

```robot
Test case  # comment1
   [Documentation]  this is
   Keyword1
   # comment2
   Keyword2
   # comment3
   Keyword3
   [Teardown]  teardown
```

However before this patch the output would be:

```robot
Test case  [Documentation]  this is
   # comment1
   Keyword1
   # comment2
   Keyword2
   # comment3
   Keyword3
   [Teardown]  teardown
```