### PR TITLE
Add skip_types parameter to AlignVariablesSection transformer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Transformers
+- Add `skip_types` parameter to `AlignVariablesSection` which allows to not align variables of particular type ([#225](https://github.com/MarketSquare/robotframework-tidy/issues/225))
+
 ## 1.6.2
 
 ### Fixes

--- a/docs/source/transformers/AlignVariablesSection.rst
+++ b/docs/source/transformers/AlignVariablesSection.rst
@@ -72,7 +72,7 @@ You can configure it to align three columns::
 
 To align all columns set ``up_to_column`` to 0.
 
-Select lines to transform
+Select lines to align
 -------------------------
 AlignVariablesSection does also support global formatting params ``startline`` and ``endline``::
 
@@ -121,3 +121,39 @@ AlignVariablesSection does also support global formatting params ``startline`` a
         *** Keywords ***
         Keyword
             Keyword Call
+
+Select variable types to align
+-------------------------------
+It is possible to not align variables of given types. You can choose between following types: `scalar` (`$`), `list` (`@`),
+`dict` (`&`). Invalid variables - such as missing values or not left aligned - will be always aligned no matter the type.
+You can configure types to skip using `skip_types` parameter::
+
+    robotidy --configure AlignVariablesSection:skip_types=dict,list src
+
+`skip_types` accepts comma separated list of types.
+
+Using above configuration code will be aligned in following way:
+
+.. tabs::
+
+    .. code-tab:: robotframework Before
+
+        *** Variables ***
+        ${VARIABLE 1}  10  # comment
+        @{LIST}  a
+        ...    b
+        ...    c
+        ...    d
+        ${LONGER_NAME_THAT_GOES_AND_GOES}    longer value that goes and goes
+        &{SOME_DICT}    key=value  key2=value
+
+    .. code-tab:: robotframework After
+
+        *** Variables ***
+        ${VARIABLE 1}                           10    # comment
+        @{LIST}  a
+        ...    b
+        ...    c
+        ...    d
+        ${LONGER_NAME_THAT_GOES_AND_GOES}       longer value that goes and goes
+        &{SOME_DICT}    key=value  key2=value

--- a/robotidy/transformers/AlignVariablesSection.py
+++ b/robotidy/transformers/AlignVariablesSection.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 
+import click
 from robot.api.parsing import ModelTransformer, Token
 from robot.parsing.model import Statement
 
@@ -39,8 +40,31 @@ class AlignVariablesSection(ModelTransformer):
     See https://robotidy.readthedocs.io/en/latest/transformers/AlignVariablesSection.html for more examples.
     """
 
-    def __init__(self, up_to_column: int = 2):
+    def __init__(self, up_to_column: int = 2, skip_types: str = ""):
         self.up_to_column = up_to_column - 1
+        self.skip_types = self.parse_skip_types(skip_types)
+
+    @staticmethod
+    def parse_skip_types(skip_types):
+        allow_types = {"dict": "&", "list": "@", "scalar": "$"}
+        ret = set()
+        if not skip_types:
+            return ret
+        for skip_type in skip_types.split(","):
+            if skip_type not in allow_types:
+                raise click.BadOptionUsage(
+                    option_name="transform",
+                    message=f"Invalid configurable value: '{skip_type}' for skip_type for AlignVariablesSection "
+                    "transformer. Variable types should be provided in comma separated list:\n"
+                    f"skip_type=dict,list,scalar",
+                )
+            ret.add(allow_types[skip_type])
+        return ret
+
+    def should_parse(self, node):
+        if not node.name:
+            return True
+        return node.name[0] not in self.skip_types
 
     def visit_VariableSection(self, node):  # noqa
         if node_outside_selection(node, self.formatting_config):
@@ -51,8 +75,10 @@ class AlignVariablesSection(ModelTransformer):
                 statements.append(child)
             elif child.type in (Token.EOL, Token.COMMENT):
                 statements.append(left_align(child))
-            else:
+            elif self.should_parse(child):
                 statements.append(list(tokens_by_lines(child)))
+            else:
+                statements.append(child)
         nodes_to_be_aligned = [st for st in statements if isinstance(st, list)]
         if not nodes_to_be_aligned:
             return node

--- a/tests/atest/transformers/AlignVariablesSection/expected/align_selected_skip.robot
+++ b/tests/atest/transformers/AlignVariablesSection/expected/align_selected_skip.robot
@@ -1,0 +1,20 @@
+*** Settings ***
+Documentation    This is doc
+
+
+*** Variables ***
+# some comment
+
+${VARIABLE 1}  10  # comment
+@{LIST}             a    b    c    d
+${LONGER_NAME_THAT_GOES_AND_GOES}    longer value that goes and goes
+
+&{MULTILINE}        a=b
+...                 b=c
+...                 d=1
+${invalid}
+${invalid_more}
+
+*** Keywords ***
+Keyword
+    Keyword Call

--- a/tests/atest/transformers/AlignVariablesSection/expected/multiline_skip.robot
+++ b/tests/atest/transformers/AlignVariablesSection/expected/multiline_skip.robot
@@ -1,0 +1,8 @@
+*** Variables ***
+${VARIABLE 1}                           10    # comment
+@{LIST}  a
+...    b
+...    c
+...    d
+${LONGER_NAME_THAT_GOES_AND_GOES}       longer value that goes and goes
+&{SOME_DICT}    key=value  key2=value

--- a/tests/atest/transformers/AlignVariablesSection/expected/tests_skip.robot
+++ b/tests/atest/transformers/AlignVariablesSection/expected/tests_skip.robot
@@ -1,0 +1,16 @@
+*** Variables ***
+# some comment
+
+${VARIABLE 1}                           10    # comment
+@{LIST}  a  b  c  d
+${LONGER_NAME_THAT_GOES_AND_GOES}       longer value that goes and goes
+
+&{MULTILINE}                            a=b
+...                                     b=c
+...                                     d=1
+${invalid}
+${invalid_more}
+
+# should be left aligned
+# should be left aligned
+${variable}                             1

--- a/tests/atest/transformers/AlignVariablesSection/source/multiline_skip.robot
+++ b/tests/atest/transformers/AlignVariablesSection/source/multiline_skip.robot
@@ -1,0 +1,8 @@
+*** Variables ***
+${VARIABLE 1}  10  # comment
+@{LIST}  a
+...    b
+...    c
+...    d
+${LONGER_NAME_THAT_GOES_AND_GOES}    longer value that goes and goes
+&{SOME_DICT}    key=value  key2=value

--- a/tests/atest/transformers/AlignVariablesSection/test_transformer.py
+++ b/tests/atest/transformers/AlignVariablesSection/test_transformer.py
@@ -41,3 +41,19 @@ class TestAlignVariablesSection:
 
     def test_multiline_with_blank(self):
         run_tidy_and_compare(self.TRANSFORMER_NAME, source="multiline_with_blank.robot")
+
+    def test_align_variables_skip(self):
+        run_tidy_and_compare(
+            self.TRANSFORMER_NAME, source="tests.robot", expected="tests_skip.robot", config=":skip_types=dict,list"
+        )
+
+    def test_align_variables_skip_scalar(self):
+        run_tidy_and_compare(
+            self.TRANSFORMER_NAME,
+            source="align_selected.robot",
+            expected="align_selected_skip.robot",
+            config=":skip_types=scalar",
+        )
+
+    def test_multiline_skip(self):
+        run_tidy_and_compare(self.TRANSFORMER_NAME, source="multiline_skip.robot", config=":skip_types=list,dict")


### PR DESCRIPTION
It allows to not align variables of given types

Closes #225 