### PR TITLE
Validate transformer names in configuration

### DIFF
--- a/robotidy/transformers/AddMissingEnd.py
+++ b/robotidy/transformers/AddMissingEnd.py
@@ -1,4 +1,5 @@
 from robot.api.parsing import ModelTransformer, Token, End, Comment, EmptyLine
+
 try:
     from robot.api.parsing import InlineIfHeader
 except ImportError:

--- a/robotidy/transformers/AlignVariablesSection.py
+++ b/robotidy/transformers/AlignVariablesSection.py
@@ -56,7 +56,7 @@ class AlignVariablesSection(ModelTransformer):
                     self.__class__.__name__,
                     "skip_type",
                     skip_type,
-                    "Variable types should be provided in comma separated list:\nskip_type=dict,list,scalar"
+                    "Variable types should be provided in comma separated list:\nskip_type=dict,list,scalar",
                 )
             ret.add(allow_types[skip_type])
         return ret

--- a/robotidy/transformers/InlineIf.py
+++ b/robotidy/transformers/InlineIf.py
@@ -136,7 +136,11 @@ class InlineIf(ModelTransformer):
 
     @staticmethod
     def if_len(if_st):
-        return sum(len(tok.value) for tok in chain(if_st.body[0].tokens if if_st.body else [], if_st.header.tokens) if tok.value != "\n")
+        return sum(
+            len(tok.value)
+            for tok in chain(if_st.body[0].tokens if if_st.body else [], if_st.header.tokens)
+            if tok.value != "\n"
+        )
 
     def to_inline(self, node, indent):
         tail = node

--- a/robotidy/transformers/NormalizeSeparators.py
+++ b/robotidy/transformers/NormalizeSeparators.py
@@ -1,6 +1,7 @@
 from itertools import takewhile
 
 from robot.api.parsing import ModelTransformer, Token
+
 try:
     from robot.api.parsing import InlineIfHeader
 except ImportError:
@@ -87,7 +88,7 @@ class NormalizeSeparators(ModelTransformer):
     def visit_TestCase(self, node):  # noqa
         return self.indented_block(node)
 
-    visit_Keyword = visit_While = visit_TestCase # noqa
+    visit_Keyword = visit_While = visit_TestCase  # noqa
 
     def visit_For(self, node):
         node = self.indented_block(node)

--- a/robotidy/transformers/__init__.py
+++ b/robotidy/transformers/__init__.py
@@ -109,10 +109,22 @@ def get_args(transformer, allowed_mapped, config):
         raise InvalidParameterFormatError(transformer) from None
 
 
+def validate_config(config, allowed_mapped):
+    for transformer in config:
+        if transformer in allowed_mapped or transformer in TRANSFORMERS:
+            continue
+        similar_finder = RecommendationFinder()
+        similar = similar_finder.find_similar(transformer, TRANSFORMERS + list(allowed_mapped.keys()))
+        raise ImportTransformerError(
+            f"Configuring transformer '{transformer}' failed. " f"Verify if correct name was provided.{similar}"
+        ) from None
+
+
 def load_transformers(allowed_transformers, config, allow_disabled=False, force_order=False):
     """Dynamically load all classes from this file with attribute `name` defined in allowed_transformers"""
     loaded_transformers = []
     allowed_mapped = {name: args for name, args in allowed_transformers} if allowed_transformers else {}
+    validate_config(config, allowed_mapped)
     if not force_order:
         for name in TRANSFORMERS:
             if not allowed_mapped or name in allowed_mapped:

--- a/tests/atest/transformers/__init__.py
+++ b/tests/atest/transformers/__init__.py
@@ -35,7 +35,9 @@ def display_file_diff(expected, actual):
 class TransformerAcceptanceTest:
     TRANSFORMER_NAME: str = "DUMMY"
 
-    def compare(self, source: str, expected: Optional[str] = None, config: str = "", target_version: Optional[int] = None):
+    def compare(
+        self, source: str, expected: Optional[str] = None, config: str = "", target_version: Optional[int] = None
+    ):
         if not enabled_in_version(self.TRANSFORMER_NAME, target_version):
             return
         if expected is None:

--- a/tests/utest/test_cli.py
+++ b/tests/utest/test_cli.py
@@ -33,12 +33,30 @@ class TestCli:
             ("AssignmentNormalizer", " Did you mean:\n    NormalizeAssignments"),
         ],
     )
-    def test_not_existing_transformer(self, name, similar):
+    def test_transform_not_existing_transformer(self, name, similar):
         expected_output = (
             f"Error: Importing transformer '{name}' failed. "
             f"Verify if correct name or configuration was provided.{similar}\n"
         )
         args = f"--transform {name} --transform MissingTransformer --transform DiscardEmptySections -".split()
+        result = run_tidy(args, exit_code=1)
+        assert expected_output == result.output
+
+    @pytest.mark.parametrize(
+        "name, similar",
+        [
+            ("NotExisting", ""),
+            ("AlignSettings", " Did you mean:\n    AlignSettingsSection"),
+            ("align", " Did you mean:\n    AlignSettingsSection\n    AlignVariablesSection"),
+            ("splittoolongline", " Did you mean:\n    SplitTooLongLine"),
+            ("AssignmentNormalizer", " Did you mean:\n    NormalizeAssignments"),
+        ],
+    )
+    def test_configure_not_existing_transformer(self, name, similar):
+        expected_output = (
+            f"Error: Configuring transformer '{name}' failed. " f"Verify if correct name was provided.{similar}\n"
+        )
+        args = f"--configure {name}:param=value -".split()
         result = run_tidy(args, exit_code=1)
         assert expected_output == result.output
 


### PR DESCRIPTION
Transformer names were validated when used with ``--transform`` but not with ``--configure``. It means that following command:

```
robotidy --configure InlineI:line_length=100
```

should fail (because of the typo in transformer name) but did not and `InlineIf` was executed without being configured.