### PR TITLE
use tomli instead of deprecated toml

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -42,7 +42,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r tests/packages/${{ matrix.rf-version }}/requirements.txt
-        pip install pytest pylama pylama_pylint coverage click pathspec>=0.8.0 toml
+        pip install pytest pylama pylama_pylint coverage click pathspec>=0.8.0 tomli
 #    - name: Code quality with pylama
     - name: Run unit tests with coverage
       run:

--- a/robotidy/files.py
+++ b/robotidy/files.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Pattern, Tuple
 
 import click
-import toml
+import tomli
 from pathspec import PathSpec
 
 DEFAULT_EXCLUDES = r"/(\.direnv|\.eggs|\.git|\.hg|\.nox|\.tox|\.venv|venv|\.svn)/"
@@ -58,9 +58,10 @@ def find_and_read_config(src_paths: Iterable[str]) -> Dict[str, Any]:
 
 def load_toml_file(path: str) -> Dict[str, Any]:
     try:
-        config = toml.load(path)
+        with Path(path).open("rb") as tf:
+            config = tomli.load(tf)
         return config
-    except (toml.TomlDecodeError, OSError) as e:
+    except (tomli.TOMLDecodeError, OSError) as e:
         raise click.FileError(filename=path, hint=f"Error reading configuration file: {e}")
 
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "packaging>=21.0",
         "pathspec>=0.9.0,<0.10.0",
         "robotframework>=4.0",
-        "toml>=0.10.2",
+        "tomli>=2.0.0",
     ],
     extras_requires={
         "dev": [

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,11 @@ envlist = rf4, rf5
 skip_missing_interpreters = true
 
 [testenv:rf4]
-deps = 
+deps =
     pytest
     robotframework==4.*
     Click>=7.0
-    toml>=0.10.2
+    tomli>=2.0.0
     colorama>=0.4.3
     pathspec==0.9.0
 commands =
@@ -17,7 +17,7 @@ deps =
     pytest
     robotframework==5.0
     Click>=7.0
-    toml>=0.10.2
+    tomli>=2.0.0
     colorama>=0.4.3
     pathspec==0.9.0
 commands =
@@ -28,7 +28,7 @@ deps =
     robotframework==5.0a1
     coverage
     Click>=7.0
-    toml>=0.10.2
+    tomli>=2.0.0
     colorama>=0.4.3
     pathspec==0.9.0
 commands =
@@ -43,7 +43,7 @@ deps =
     robotframework==5.0a1
     coverage
     Click>=7.0
-    toml>=0.10.2
+    tomli>=2.0.0
     colorama>=0.4.3
     pathspec==0.9.0
 commands =


### PR DESCRIPTION
Hi, folks, thanks for `robotframework-tidy`!

This PR replaces use of the unmaintained `toml` with `tomli`, which is both maintained and supports the full `1.0` spec. 

This should tide us over until [PEP-680](https://peps.python.org/pep-0680/) `tomllib`  is widely distributed... but it's probably not worth adding a conditional until python 3.11 is actually released.