### PR TITLE
Improve Skip argument handling

### DIFF
--- a/robotidy/transformers/AlignKeywordsSection.py
+++ b/robotidy/transformers/AlignKeywordsSection.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     InlineIfHeader, TryHeader = None, None
 
-from robotidy.disablers import skip_if_disabled
+from robotidy.disablers import Skip, skip_if_disabled
 from robotidy.transformers.aligners_core import AlignKeywordsTestsSection
 
 
@@ -19,21 +19,14 @@ class AlignKeywordsSection(AlignKeywordsTestsSection):
         widths: str = "",
         alignment_type: str = "fixed",
         handle_too_long: str = "overflow",
-        skip_documentation: bool = True,
-        skip_return_values: bool = False,
-        skip_keyword_call: str = "",
-        skip_keyword_call_contains: str = "",
-        skip_keyword_call_starts_with: str = "",
+        skip_documentation: str = "True",  # noqa - override skip_documentation from Skip
+        skip: Skip = None,
     ):
         super().__init__(
             widths,
             alignment_type,
             handle_too_long,
-            skip_documentation,
-            skip_return_values,
-            skip_keyword_call,
-            skip_keyword_call_contains,
-            skip_keyword_call_starts_with,
+            skip,
         )
 
     @skip_if_disabled

--- a/robotidy/transformers/AlignTestCasesSection.py
+++ b/robotidy/transformers/AlignTestCasesSection.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     InlineIfHeader, TryHeader = None, None
 
-from robotidy.disablers import skip_if_disabled
+from robotidy.disablers import Skip, skip_if_disabled
 from robotidy.transformers.aligners_core import AlignKeywordsTestsSection
 from robotidy.utils import is_suite_templated
 
@@ -20,22 +20,10 @@ class AlignTestCasesSection(AlignKeywordsTestsSection):
         widths: str = "",
         alignment_type: str = "fixed",
         handle_too_long: str = "overflow",
-        skip_documentation: bool = True,
-        skip_return_values: bool = False,
-        skip_keyword_call: str = "",
-        skip_keyword_call_contains: str = "",
-        skip_keyword_call_starts_with: str = "",
+        skip_documentation: str = "True",  # noqa - override skip_documentation from Skip
+        skip: Skip = None,
     ):
-        super().__init__(
-            widths,
-            alignment_type,
-            handle_too_long,
-            skip_documentation,
-            skip_return_values,
-            skip_keyword_call,
-            skip_keyword_call_contains,
-            skip_keyword_call_starts_with,
-        )
+        super().__init__(widths, alignment_type, handle_too_long, skip)
 
     def visit_File(self, node):  # noqa
         if is_suite_templated(node):

--- a/robotidy/transformers/NormalizeSeparators.py
+++ b/robotidy/transformers/NormalizeSeparators.py
@@ -25,8 +25,7 @@ class NormalizeSeparators(Transformer):
     Supports global formatting params: ``--startline`` and ``--endline``.
     """
 
-    def __init__(self, sections: str = None, skip_documentation: bool = False):
-        skip = Skip(documentation=skip_documentation)
+    def __init__(self, sections: str = None, skip: Skip = None):
         super().__init__(skip=skip)
         self.indent = 0
         self.sections = self.parse_sections(sections)

--- a/robotidy/transformers/aligners_core.py
+++ b/robotidy/transformers/aligners_core.py
@@ -24,19 +24,8 @@ class AlignKeywordsTestsSection(Transformer):
         widths: str,
         alignment_type: str,
         handle_too_long: str,
-        skip_documentation: bool,
-        skip_return_values: bool,
-        skip_keyword_call: str,
-        skip_keyword_call_contains: str,
-        skip_keyword_call_starts_with: str,
+        skip: Skip = None,
     ):
-        skip = Skip(
-            documentation=skip_documentation,
-            return_values=skip_return_values,
-            keyword_call=skip_keyword_call,
-            keyword_call_contains=skip_keyword_call_contains,
-            keyword_call_starts_with=skip_keyword_call_starts_with,
-        )
         super().__init__(skip)
         self.is_inline = False
         self.indent = 1

--- a/tests/utest/test_disablers.py
+++ b/tests/utest/test_disablers.py
@@ -68,65 +68,82 @@ def test_register_disablers(test_file, expected_lines, file_disabled, rf_version
     assert register_disablers.file_disabled == file_disabled
 
 
-@pytest.mark.parametrize(
-    "skip_config, names, disabled",
-    [
-        ("executejavascript", ["Execute Javascript"], [True]),
-        ("executejavascript", ["OtherLib.Execute Javascript"], [False]),
-        ("executejavascript", ["Keyword"], [False]),
-        ("Execute_Javascript", ["Keyword", "Execute_Javas cript"], [False, True]),
-        ("executejavascript", [None], [False]),
-        (None, ["Execute Javascript"], [False]),
-        (
-            "executejavascript,otherkeyword",
-            ["Execute Javascript", "Test Keyword", "Other_keyword"],
-            [True, False, True],
-        ),
-    ],
-)
-def test_skip_keyword_call(skip_config, names, disabled):
-    mock_node = Mock()
-    skip = Skip(keyword_call=skip_config)
-    for name, disable in zip(names, disabled):
-        mock_node.keyword = name
-        assert disable == skip.keyword_call(mock_node)
+class TestSkip:
+    @pytest.mark.parametrize("keyword_call, str_keyword_call", [(["test", "keyword"], "test,keyword"), (None, "")])
+    @pytest.mark.parametrize("return_values, str_return_values", [(True, "True"), (False, "False")])
+    @pytest.mark.parametrize("doc, str_doc", [(True, "True"), (False, "False")])
+    def test_from_str_cfg(self, doc, str_doc, return_values, str_return_values, keyword_call, str_keyword_call):
+        skip_from_str = Skip.from_str_config(
+            documentation=str_doc, return_values=str_return_values, keyword_call=str_keyword_call
+        )
+        skip = Skip(documentation=doc, return_values=return_values, keyword_call=keyword_call)
+        assert skip_from_str == skip
 
+    @pytest.mark.parametrize(
+        "skip_config, names, disabled",
+        [
+            ("executejavascript", ["Execute Javascript"], [True]),
+            ("executejavascript", ["OtherLib.Execute Javascript"], [False]),
+            ("executejavascript", ["Keyword"], [False]),
+            ("Execute_Javascript", ["Keyword", "Execute_Javas cript"], [False, True]),
+            ("executejavascript", [None], [False]),
+            (None, ["Execute Javascript"], [False]),
+            (
+                "executejavascript,otherkeyword",
+                ["Execute Javascript", "Test Keyword", "Other_keyword"],
+                [True, False, True],
+            ),
+        ],
+    )
+    def test_skip_keyword_call(self, skip_config, names, disabled):
+        mock_node = Mock()
+        skip = Skip.from_str_config(keyword_call=skip_config)
+        for name, disable in zip(names, disabled):
+            mock_node.keyword = name
+            assert disable == skip.keyword_call(mock_node)
 
-@pytest.mark.parametrize(
-    "skip_config, names, disabled",
-    [
-        ("executejavascript", ["Execute Javascript"], [True]),
-        ("Execute Javascript", ["executejavascript"], [True]),
-        ("executejavascript", ["Keyword"], [False]),
-        ("Execute", ["Execute Javascript"], [True]),
-        ("Execute1", ["Execute Javascript"], [False]),
-        ("Execute", ["Execute Javascript", "Execute Other Stuff", "Keyword"], [True, True, False]),
-        ("Library.", ["Library.Stuff", "Library2.Stuff", "library.Other_stuff", "library"], [True, False, True, False]),
-        (None, ["Execute Javascript"], [False]),
-        ("executejavascript", [None], [False]),
-    ],
-)
-def test_skip_keyword_call_starts_with(skip_config, names, disabled):
-    mock_node = Mock()
-    skip = Skip(keyword_call_starts_with=skip_config)
-    for name, disable in zip(names, disabled):
-        mock_node.keyword = name
-        assert disable == skip.keyword_call(mock_node)
+    @pytest.mark.parametrize(
+        "skip_config, names, disabled",
+        [
+            ("executejavascript", ["Execute Javascript"], [True]),
+            ("Execute Javascript", ["executejavascript"], [True]),
+            ("executejavascript", ["Keyword"], [False]),
+            ("Execute", ["Execute Javascript"], [True]),
+            ("Execute1", ["Execute Javascript"], [False]),
+            ("Execute", ["Execute Javascript", "Execute Other Stuff", "Keyword"], [True, True, False]),
+            (
+                "Library.",
+                ["Library.Stuff", "Library2.Stuff", "library.Other_stuff", "library"],
+                [True, False, True, False],
+            ),
+            (None, ["Execute Javascript"], [False]),
+            ("executejavascript", [None], [False]),
+        ],
+    )
+    def test_skip_keyword_call_starts_with(self, skip_config, names, disabled):
+        mock_node = Mock()
+        skip = Skip.from_str_config(keyword_call_starts_with=skip_config)
+        for name, disable in zip(names, disabled):
+            mock_node.keyword = name
+            assert disable == skip.keyword_call(mock_node)
 
-
-@pytest.mark.parametrize(
-    "skip_config, names, disabled",
-    [
-        ("java", ["Java", "javascript", "script"], [True, True, False]),
-        ("javascript", ["java", "javascript", "Execute Javascript"], [False, True, True]),
-        ("Library.", ["Library.Stuff", "Library2.Stuff", "library.Other_stuff", "library"], [True, False, True, False]),
-        (None, ["Keyword"], [False]),
-        ("Keyword", [None], [False]),
-    ],
-)
-def test_skip_keyword_call_contains(skip_config, names, disabled):
-    mock_node = Mock()
-    skip = Skip(keyword_call_contains=skip_config)
-    for name, disable in zip(names, disabled):
-        mock_node.keyword = name
-        assert disable == skip.keyword_call(mock_node)
+    @pytest.mark.parametrize(
+        "skip_config, names, disabled",
+        [
+            ("java", ["Java", "javascript", "script"], [True, True, False]),
+            ("javascript", ["java", "javascript", "Execute Javascript"], [False, True, True]),
+            (
+                "Library.",
+                ["Library.Stuff", "Library2.Stuff", "library.Other_stuff", "library"],
+                [True, False, True, False],
+            ),
+            (None, ["Keyword"], [False]),
+            ("Keyword", [None], [False]),
+        ],
+    )
+    def test_skip_keyword_call_contains(self, skip_config, names, disabled):
+        mock_node = Mock()
+        skip = Skip.from_str_config(keyword_call_contains=skip_config)
+        for name, disable in zip(names, disabled):
+            mock_node.keyword = name
+            assert disable == skip.keyword_call(mock_node)


### PR DESCRIPTION
Related #310 

Now skip arguments works similarly as ``enabled`` argument - which is accepted by all transformers but it doesn't need to be defined in ``__init__`` of transformer class.

The new logic works in following way:
If any of provided arguments (to transformer) match those handled by Skip.HANDLES set, it will be parsed and then used to create instance of Skip class. If the transformer accept ``skip`` argument, this instance will be passed when creating transformer instance.

Improved our core methods as well and added docs.