### PR TITLE
Replace skip_keyword_starts_with and contains with regex patterns

### DIFF
--- a/docs/source/configuration/index.rst
+++ b/docs/source/configuration/index.rst
@@ -9,6 +9,7 @@ Configuration
 
    config_file
    configuring_transformers
+   skip_formatting
 
 Behaviour of *robotidy* can be changed through global options or by configuring specific transformer.
 To read more about configuring transformer go to :ref:`configuring-transformers`. To see how to configure robotidy

--- a/docs/source/configuration/skip_formatting.rst
+++ b/docs/source/configuration/skip_formatting.rst
@@ -1,0 +1,60 @@
+.. _skip_formatting:
+
+Skip formatting
+================
+.. rubric:: Skip formatting
+
+It is possible to skip formatting on code that matches given criteria.
+Following transformers provide support for skip option:
+
+- :ref:`AlignKeywordsSection`
+- :ref:`AlignTestCasesSection`
+- :ref:`NormalizeSeparators`
+
+To see what types are possible to skip see ``Skip formatting`` sections in each transformer documentation.
+
+.. _skip documentation:
+
+Skip documentation
+-------------------
+Flag that disables formatting the documentation. Example usage::
+
+    robotidy -c NormalizeSeparators:skip_documentation=True src
+
+.. _skip return_values:
+
+Skip return values
+-------------------
+Flag that disables formatting the return values (assignments). Example usage::
+
+    robotidy -c AlignKeywordsSection:skip_return_values=True src
+
+.. _skip keyword call:
+
+Skip keyword call
+------------------
+Comma separated list of keyword call names that should not be formatted. Names will be
+normalized before search (spaces and underscores removed, lowercase).
+
+With this configuration::
+
+    robotidy -c AlignTestCasesSection:skip_keyword_call=ExecuteJavascript,catenate
+
+All instances of ``Execute Javascript`` and ``Catenate`` keywords will not be formatted.
+
+.. _skip keyword call pattern:
+
+Skip keyword call pattern
+-------------------------
+Comma separated list of keyword call name patterns that should not be formatted. The keyword names are not normalized.
+If you're using different case for the same keyword ("Keyword" and "keyword") or using both spaces and underscores it is
+recommended to use proper regex flags to match it properly.
+
+With this configuration::
+
+    robotidy -c AlignKeywordsSection:skip_keyword_call_pattern=^First,(i?)contains\s?words src
+
+All instances of keywords that starts with "First" or contains "contains words" (case insensitive, space optional) will
+not be formatted.
+
+Note that list is comma separated - it is currently not possible to provide regex with ``,``.

--- a/docs/source/external_transformers.rst
+++ b/docs/source/external_transformers.rst
@@ -1,7 +1,7 @@
 .. _external-transformers:
 
 External transformers
--------------------------------
+======================
 It is possible to develop your own transformers. You can use module name (if it is installed in your env) or path to
 file with class to run external transformers with *robotidy*::
 
@@ -50,7 +50,7 @@ Configurable params should be supplied through ``__init__`` together with the ty
             return node
 
 ModelTransformer vs Transformer
--------------------------------
+--------------------------------
 Instead of using RobotFramework ``ModelTransformer`` class directly, it is possible to inherit from Robotidy ``Transformer``
 class:
 

--- a/docs/source/transformers/AlignKeywordsSection.rst
+++ b/docs/source/transformers/AlignKeywordsSection.rst
@@ -10,3 +10,12 @@ Short description.
 
 
 Long description with code examples.
+
+Skip formatting
+----------------
+It is possible to use following arguments to skip formatting the code:
+
+- :ref:`skip documentation`
+- :ref:`skip return values`
+- :ref:`skip keyword call`
+- :ref:`skip keyword call pattern`

--- a/docs/source/transformers/AlignTestCasesSection.rst
+++ b/docs/source/transformers/AlignTestCasesSection.rst
@@ -1,6 +1,6 @@
 .. _AlignTestCasesSection:
 
-_AlignTestCasesSection
+AlignTestCasesSection
 ================================
 Short description.
 
@@ -10,3 +10,12 @@ Short description.
 
 
 Long description with code examples.
+
+Skip formatting
+----------------
+It is possible to use following arguments to skip formatting the code:
+
+- :ref:`skip documentation`
+- :ref:`skip return values`
+- :ref:`skip keyword call`
+- :ref:`skip keyword call pattern`

--- a/docs/source/transformers/NormalizeSeparators.rst
+++ b/docs/source/transformers/NormalizeSeparators.rst
@@ -126,8 +126,13 @@ Combine it with ``spacecount`` to set whitespace separately for indent and separ
                 Keyword With  ${var}
             END
 
-Formatting documentation
---------------------------
+Skip formatting
+----------------
+It is possible to use following arguments to skip formatting the code:
+
+- :ref:`skip documentation`
+- :ref:`skip keyword call`
+- :ref:`skip keyword call pattern`
 
 Documentation is formatted by default. To disable formatting the separators inside documentation, and to only format
 indentation, set ``skip_documentation`` to ``True``::

--- a/robotidy/transformers/NormalizeSeparators.py
+++ b/robotidy/transformers/NormalizeSeparators.py
@@ -129,6 +129,11 @@ class NormalizeSeparators(Transformer):
             return self._handle_spaces(doc, has_pipes, only_indent=True)
         return self.visit_Statement(doc)
 
+    def visit_KeywordCall(self, keyword):  # noqa
+        if self.skip.keyword_call(keyword):
+            return keyword
+        return self.visit_Statement(keyword)
+
     def is_keyword_inside_inline_if(self, node):
         return self.is_inline and isinstance(node, KeywordCall)
 

--- a/tests/atest/transformers/AlignKeywordsSection/test_transformer.py
+++ b/tests/atest/transformers/AlignKeywordsSection/test_transformer.py
@@ -73,8 +73,7 @@ class TestAlignKeywordsSection(TransformerAcceptanceTest):
         self.compare(
             "skip_keywords.robot",
             config=":skip_keyword_call=should_not_be_none"
-            ":skip_keyword_call_contains=contain"
-            ":skip_keyword_call_starts_with=prefix"
+            ":skip_keyword_call_pattern=Contain,^(?i)prefix"
             ":skip_return_values=True",
         )
 

--- a/tests/atest/transformers/AlignTestCasesSection/test_transformer.py
+++ b/tests/atest/transformers/AlignTestCasesSection/test_transformer.py
@@ -73,8 +73,7 @@ class TestAlignTestCasesSection(TransformerAcceptanceTest):
         self.compare(
             "skip_keywords.robot",
             config=":skip_keyword_call=should_not_be_none"
-            ":skip_keyword_call_contains=contain"
-            ":skip_keyword_call_starts_with=prefix"
+            ":skip_keyword_call_pattern=Contain,^(?i)prefix"
             ":skip_return_values=True",
         )
 

--- a/tests/atest/transformers/NormalizeSeparators/expected/test_skip_keyword.robot
+++ b/tests/atest/transformers/NormalizeSeparators/expected/test_skip_keyword.robot
@@ -1,0 +1,50 @@
+# this is    comment
+
+*** Settings ***
+Library    library.py    WITH NAME    alias
+
+Force Tags    tag
+...    tag
+
+Documentation    doc
+...    multi
+...    line
+
+*** Variables ***
+${var}    3
+ ${var2}    4
+
+*** Test Cases ***
+Test case
+    [Setup]    Keyword
+    [Documentation]    First word    Second word
+    Keyword    with    arg
+    ...    and    multi    lines
+    [Teardown]    Keyword
+
+Test case with structures
+    FOR    ${variable}    IN    1    2
+        Keyword
+        IF    ${condition}
+            Log    ${stuff}    console=True
+        END
+    END
+
+*** Keywords ***
+Keyword
+Another Keyword
+    [Arguments]    ${arg}
+    [Documentation]    First word    Second word
+    ...    Third.
+       Should Be Equal  1
+       ...  ${arg}
+    IF    ${condition}
+        FOR    ${v}    IN RANGE    10
+            Keyword
+        END
+    END
+
+Keyword With Tabulators
+    Keyword
+    ...    2
+    ...    ${arg}

--- a/tests/atest/transformers/NormalizeSeparators/test_transformer.py
+++ b/tests/atest/transformers/NormalizeSeparators/test_transformer.py
@@ -66,3 +66,10 @@ class TestNormalizeSeparators(TransformerAcceptanceTest):
             not_modified=not_modified,
             target_version=5,
         )
+
+    def test_skip_keyword_call(self):
+        self.compare(
+            source="test.robot",
+            expected="test_skip_keyword.robot",
+            config=":skip_keyword_call_pattern=(?i)should\sbe\sequal",
+        )


### PR DESCRIPTION
Relates #310 

Instead of using several different argument I've introduced single argument that accept regex pattern for skipping the keyword call names. Also added the documentation for skip formatting and fixed minor issues in docs.