### PR TITLE
Define skip parameters globally

### DIFF
--- a/docs/source/configuration/skip_formatting.rst
+++ b/docs/source/configuration/skip_formatting.rst
@@ -21,6 +21,22 @@ Flag that disables formatting of the documentation. Example usage::
 
     robotidy -c NormalizeSeparators:skip_documentation=True src
 
+It is possible to use global flag to skip formatting for every transformer that supports it::
+
+    robotidy --skip-documentation src
+
+Configuration file
+~~~~~~~~~~~~~~~~~~~~
+Both options are configurable using configuration file (:ref:`config-file`).
+
+.. code-block:: toml
+
+    [tool.robotidy]
+    skip-documentation = true
+    configure = [
+        "NormalizeSeparators:skip_documentation=False"
+    ]
+
 .. _skip return_values:
 
 Skip return values
@@ -28,6 +44,22 @@ Skip return values
 Flag that disables formatting of the return values (assignments). Example usage::
 
     robotidy -c AlignKeywordsSection:skip_return_values=True src
+
+It is possible to use global flag to skip formatting for every transformer that supports it::
+
+    robotidy --skip-return-values src
+
+Configuration file
+~~~~~~~~~~~~~~~~~~~~
+Both options are configurable using configuration file (:ref:`config-file`).
+
+.. code-block:: toml
+
+    [tool.robotidy]
+    skip-return-values = true
+    configure = [
+        "AlignKeywordsSection:skip_return_values=False"
+    ]
 
 .. _skip keyword call:
 
@@ -41,6 +73,25 @@ With this configuration::
     robotidy -c AlignTestCasesSection:skip_keyword_call=ExecuteJavascript,catenate
 
 All instances of ``Execute Javascript`` and ``Catenate`` keywords will not be formatted.
+
+It is possible to use global option to skip formatting for every transformer that supports it::
+
+    robotidy --skip-keyword-call Name --skip-keyword-call othername src
+
+Configuration file
+~~~~~~~~~~~~~~~~~~~~
+Both options are configurable using configuration file (:ref:`config-file`).
+
+.. code-block:: toml
+
+    [tool.robotidy]
+    skip-keyword-call = [
+        "GlobalSkip",
+        "supports spaces too"
+    ]
+    configure = [
+        "AlignKeywordsSection:skip_keyword_call=Name,othername"
+    ]
 
 .. _skip keyword call pattern:
 
@@ -58,3 +109,22 @@ All instances of keywords that start with "First" or contain "contains words" (c
 not be formatted.
 
 > Note that list is comma-separated - it is currently not possible to provide regex with ``,``.
+
+It is possible to use global option to skip formatting for every transformer that supports it::
+
+    robotidy --skip-keyword-call-pattern ^Second --skip-keyword-call-pattern (i?)contains\s?words src
+
+Configuration file
+~~~~~~~~~~~~~~~~~~~~
+Both options are configurable using configuration file (:ref:`config-file`).
+
+.. code-block:: toml
+
+    [tool.robotidy]
+    skip-keyword-call-pattern = [
+        "^Second",
+        "(i?)contains\s?words"
+    ]
+    configure = [
+        "AlignKeywordsSection:skip_keyword_call_pattern=first,secondname"
+    ]

--- a/robotidy/cli.py
+++ b/robotidy/cli.py
@@ -57,6 +57,7 @@ click.rich_click.OPTION_GROUPS = {
             ],
         },
         {"name": "File exclusion", "options": ["--exclude", "--extend-exclude", "--skip-gitignore"]},
+        skip.option_group,
         {
             "name": "Other",
             "options": ["--target-version", "--verbose", "--color", "--output", "--version", "--help"],

--- a/robotidy/cli.py
+++ b/robotidy/cli.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Pattern, Tuple, Union
 
 import rich_click as click
 
+from robotidy import skip
 from robotidy.app import Robotidy
 from robotidy.config import Config, FormattingConfig
 from robotidy.decorators import catch_exceptions
@@ -388,6 +389,10 @@ def print_transformers_list(target_version: int):
     callback=validate_target_version,
     help="Only enable transformers supported in set target version. \[default: installed Robot Framework version]",
 )
+@skip.documentation_option
+@skip.return_values_option
+@skip.keyword_call_option
+@skip.keyword_call_pattern_option
 @click.version_option(version=__version__, prog_name="robotidy")
 @click.pass_context
 @catch_exceptions
@@ -418,6 +423,10 @@ def cli(
     output: Optional[Path],
     force_order: bool,
     target_version: int,
+    skip_documentation: bool,
+    skip_return_values: bool,
+    skip_keyword_call: List[str],
+    skip_keyword_call_pattern: List[str],
 ):
     """
     Robotidy is a tool for formatting Robot Framework source code.
@@ -449,6 +458,13 @@ def cli(
     if color:
         color = "NO_COLOR" not in os.environ
 
+    skip_config = skip.SkipConfig(
+        documentation=skip_documentation,
+        return_values=skip_return_values,
+        keyword_call=skip_keyword_call,
+        keyword_call_pattern=skip_keyword_call_pattern,
+    )
+
     formatting = FormattingConfig(
         space_count=spacecount,
         indent=indent,
@@ -461,6 +477,7 @@ def cli(
     )
     config = Config(
         formatting=formatting,
+        skip=skip_config,
         transformers=transform,
         transformers_config=configure,
         src=src,

--- a/robotidy/config.py
+++ b/robotidy/config.py
@@ -56,6 +56,7 @@ class Config:
     def __init__(
         self,
         formatting: FormattingConfig,
+        skip,
         transformers: List[Tuple[str, List]],
         transformers_config: List[Tuple[str, List]],
         src: Tuple[str, ...],
@@ -81,7 +82,7 @@ class Config:
         self.color = color
         transformers_config = self.convert_configure(transformers_config)
         self.transformers = load_transformers(
-            transformers, transformers_config, force_order=force_order, target_version=target_version
+            transformers, transformers_config, force_order=force_order, target_version=target_version, skip=skip
         )
         for transformer in self.transformers:
             # inject global settings TODO: handle it better

--- a/robotidy/skip.py
+++ b/robotidy/skip.py
@@ -115,10 +115,21 @@ class Skip:
         return False
 
 
-documentation_option = click.option("--skip-documentation", is_flag=True, help="Skip formatting of documentation")
-return_values_option = click.option("--skip-return-values", is_flag=True, help="Skip formatting of return values")
+documentation_option = click.option(
+    "--skip-documentation",
+    is_flag=True,
+    help="Skip formatting of documentation",
+)
+return_values_option = click.option(
+    "--skip-return-values",
+    is_flag=True,
+    help="Skip formatting of return values",
+)
 keyword_call_option = click.option(
-    "--skip-keyword-call", type=str, multiple=True, help="Keyword call name that should not be formatted"
+    "--skip-keyword-call",
+    type=str,
+    multiple=True,
+    help="Keyword call name that should not be formatted",
 )
 keyword_call_pattern_option = click.option(
     "--skip-keyword-call-pattern",
@@ -126,3 +137,7 @@ keyword_call_pattern_option = click.option(
     multiple=True,
     help="Keyword call name pattern that should not be formatted",
 )
+option_group = {
+    "name": "Skip formatting",
+    "options": ["--skip-documentation", "--skip-return-values", "--skip-keyword-call", "--skip-keyword-call-pattern"],
+}

--- a/robotidy/skip.py
+++ b/robotidy/skip.py
@@ -1,0 +1,128 @@
+import re
+from typing import List, Optional, Pattern
+
+import click
+
+from robotidy.utils import normalize_name
+
+
+def parse_csv(value):
+    if not value:
+        return []
+    return [val for val in value.split(",")]
+
+
+def str_to_bool(value):
+    return value.lower() == "true"
+
+
+def validate_regex(value: str) -> Optional[Pattern]:
+    try:
+        return re.compile(value)
+    except re.error:
+        raise ValueError(f"'{value}' is not a valid regular expression.") from None
+
+
+def join_optional_list_with_global(local: Optional[str], global_list: List):
+    if local is None:
+        return [elem for elem in global_list]
+    return parse_csv(local) + global_list
+
+
+def join_optional_flag_with_global(local: Optional[str], global_flag: bool):
+    if local is None:
+        return global_flag
+    return str_to_bool(local)
+
+
+class SkipConfig:
+    """Skip configuration (global and for each transformer)."""
+
+    # Following names will be taken from transformer config and provided to Skip class instead
+    HANDLES = frozenset(
+        {
+            "skip_documentation",
+            "skip_return_values",
+            "skip_keyword_call",
+            "skip_keyword_call_pattern",
+        }
+    )
+
+    def __init__(
+        self,
+        documentation: bool = False,
+        return_values: bool = False,
+        keyword_call: Optional[List] = None,
+        keyword_call_pattern: Optional[List] = None,
+    ):
+        self.documentation = documentation
+        self.return_values = return_values
+        self.keyword_call: List = keyword_call if keyword_call else []
+        self.keyword_call_pattern: List = keyword_call_pattern if keyword_call_pattern else []
+
+    @classmethod
+    def from_str_config(
+        cls,
+        global_skip,
+        documentation: Optional[str] = None,
+        return_values: Optional[str] = None,
+        keyword_call: Optional[str] = None,
+        keyword_call_pattern: Optional[str] = None,
+    ):
+        """Integrate local and global configurations into one (local takes precedence if specified)."""
+        documentation = join_optional_flag_with_global(documentation, global_skip.documentation)
+        return_values = join_optional_flag_with_global(return_values, global_skip.return_values)
+        keyword_call = join_optional_list_with_global(keyword_call, global_skip.keyword_call)
+        keyword_call_pattern = join_optional_list_with_global(keyword_call_pattern, global_skip.keyword_call_pattern)
+        return cls(
+            documentation=documentation,
+            return_values=return_values,
+            keyword_call=keyword_call,
+            keyword_call_pattern=keyword_call_pattern,
+        )
+
+    def __eq__(self, other):
+        return (
+            self.documentation == other.documentation
+            and self.return_values == other.return_values
+            and self.keyword_call == other.keyword_call
+            and self.keyword_call_pattern == other.keyword_call_pattern
+        )
+
+
+class Skip:
+    """Defines global skip conditions for each transformer."""
+
+    def __init__(self, skip_config: SkipConfig):
+        self.return_values = skip_config.return_values
+        self.documentation = skip_config.documentation
+        self.keyword_call_names = {normalize_name(name) for name in skip_config.keyword_call}
+        self.keyword_call_pattern = {validate_regex(pattern) for pattern in skip_config.keyword_call_pattern}
+        self.any_keword_call = self.check_any_keyword_call()
+
+    def check_any_keyword_call(self):
+        return self.keyword_call_names or self.keyword_call_pattern
+
+    def keyword_call(self, node):
+        if not getattr(node, "keyword", None) or not self.any_keword_call:
+            return False
+        normalized = normalize_name(node.keyword)
+        if normalized in self.keyword_call_names:
+            return True
+        for pattern in self.keyword_call_pattern:
+            if pattern.search(node.keyword):
+                return True
+        return False
+
+
+documentation_option = click.option("--skip-documentation", is_flag=True, help="Skip formatting of documentation")
+return_values_option = click.option("--skip-return-values", is_flag=True, help="Skip formatting of return values")
+keyword_call_option = click.option(
+    "--skip-keyword-call", type=str, multiple=True, help="Keyword call name that should not be formatted"
+)
+keyword_call_pattern_option = click.option(
+    "--skip-keyword-call-pattern",
+    type=str,
+    multiple=True,
+    help="Keyword call name pattern that should not be formatted",
+)

--- a/tests/utest/test_disablers.py
+++ b/tests/utest/test_disablers.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 import pytest
 from robot.api import get_model
 
-from robotidy.disablers import DisabledLines, RegisterDisablers, Skip
+from robotidy.disablers import DisabledLines, RegisterDisablers
 from robotidy.utils import ROBOT_VERSION
 
 
@@ -67,73 +67,3 @@ def test_register_disablers(test_file, expected_lines, file_disabled, rf_version
     register_disablers.visit(model)
     assert register_disablers.disablers.lines == expected_lines
     assert register_disablers.file_disabled == file_disabled
-
-
-class TestSkip:
-    @pytest.mark.parametrize("keyword_call, str_keyword_call", [(["test", "keyword"], "test,keyword"), (None, "")])
-    @pytest.mark.parametrize("return_values, str_return_values", [(True, "True"), (False, "False")])
-    @pytest.mark.parametrize("doc, str_doc", [(True, "True"), (False, "False")])
-    def test_from_str_cfg(self, doc, str_doc, return_values, str_return_values, keyword_call, str_keyword_call):
-        skip_from_str = Skip.from_str_config(
-            documentation=str_doc, return_values=str_return_values, keyword_call=str_keyword_call
-        )
-        skip = Skip(documentation=doc, return_values=return_values, keyword_call=keyword_call)
-        assert skip_from_str == skip
-
-    @pytest.mark.parametrize(
-        "skip_config, names, disabled",
-        [
-            ("executejavascript", ["Execute Javascript"], [True]),
-            ("executejavascript", ["OtherLib.Execute Javascript"], [False]),
-            ("executejavascript", ["Keyword"], [False]),
-            ("Execute_Javascript", ["Keyword", "Execute_Javas cript"], [False, True]),
-            ("executejavascript", [None], [False]),
-            (None, ["Execute Javascript"], [False]),
-            (
-                "executejavascript,otherkeyword",
-                ["Execute Javascript", "Test Keyword", "Other_keyword"],
-                [True, False, True],
-            ),
-        ],
-    )
-    def test_skip_keyword_call(self, skip_config, names, disabled):
-        mock_node = Mock()
-        skip = Skip.from_str_config(keyword_call=skip_config)
-        for name, disable in zip(names, disabled):
-            mock_node.keyword = name
-            assert disable == skip.keyword_call(mock_node)
-
-    @pytest.mark.parametrize(
-        "skip_config, names, disabled",
-        [
-            ("Execute Javascript", ["Execute Javascript"], [True]),
-            ("Execute Javascript", ["executejavascript"], [False]),
-            ("(?i)execute\s?javascript", ["Execute Javascript"], [True]),
-            ("executejavascript", ["Keyword"], [False]),
-            ("Javascript", ["Execute Javascript"], [True]),
-            ("^Javascript", ["Execute Javascript"], [False]),
-            ("Execute", ["Execute Javascript"], [True]),
-            ("Execute1", ["Execute Javascript"], [False]),
-            ("Execute", ["Execute Javascript", "Execute Other Stuff", "Keyword"], [True, True, False]),
-            (
-                "(?i)Library\.",
-                ["Library.Stuff", "Library2.Stuff", "library.Other_stuff", "library"],
-                [True, False, True, False],
-            ),
-            ("(?i)execute,javascript", ["Execute", "Quasadilla", "Javascript"], [True, False, False]),
-            (None, ["Execute Javascript"], [False]),
-            ("executejavascript", [None], [False]),
-        ],
-    )
-    def test_skip_keyword_call_pattern(self, skip_config, names, disabled):
-        mock_node = Mock()
-        skip = Skip.from_str_config(keyword_call_pattern=skip_config)
-        for name, disable in zip(names, disabled):
-            mock_node.keyword = name
-            assert disable == skip.keyword_call(mock_node)
-
-    def test_keyword_call_pattern_invalid(self):
-        invalid_regex = "[0-9]++"
-        msg_error = re.escape(f"'{invalid_regex}' is not a valid regular expression.")
-        with pytest.raises(ValueError, match=msg_error):
-            Skip.from_str_config(keyword_call_pattern=invalid_regex)

--- a/tests/utest/test_skip.py
+++ b/tests/utest/test_skip.py
@@ -80,3 +80,21 @@ class TestSkip:
         msg_error = re.escape(f"'{invalid_regex}' is not a valid regular expression.")
         with pytest.raises(ValueError, match=msg_error):
             Skip(skip_config=skip_config)
+
+    def test_global_local_skip_documentation(self):
+        # local overrides global
+        global_config = SkipConfig(documentation=False)
+        local_config = SkipConfig.from_str_config(global_skip=global_config, documentation="True")
+        assert local_config.documentation
+
+    def test_global_local_keyword_call(self):
+        # list are joined
+        global_config = SkipConfig(keyword_call=["name", "name2"])
+        local_config = SkipConfig.from_str_config(global_skip=global_config, keyword_call="name,name3")
+        assert local_config.keyword_call == ["name", "name3", "name", "name2"]
+
+    def test_only_global_return_values(self):
+        # global takes precedence
+        global_config = SkipConfig(return_values=True)
+        local_config = SkipConfig.from_str_config(global_skip=global_config)
+        assert local_config.return_values

--- a/tests/utest/test_skip.py
+++ b/tests/utest/test_skip.py
@@ -1,0 +1,82 @@
+import re
+from unittest.mock import Mock
+
+import pytest
+
+from robotidy.disablers import Skip, SkipConfig
+
+
+class TestSkip:
+    @pytest.mark.parametrize("keyword_call, str_keyword_call", [(["test", "keyword"], "test,keyword"), (None, "")])
+    @pytest.mark.parametrize("return_values, str_return_values", [(True, "True"), (False, "False")])
+    @pytest.mark.parametrize("doc, str_doc", [(True, "True"), (False, "False")])
+    def test_from_str_cfg(self, doc, str_doc, return_values, str_return_values, keyword_call, str_keyword_call):
+        skip_from_str = SkipConfig.from_str_config(  # TODO other tests for global_skip overrides
+            global_skip=SkipConfig(),
+            documentation=str_doc,
+            return_values=str_return_values,
+            keyword_call=str_keyword_call,
+        )
+        skip = SkipConfig(documentation=doc, return_values=return_values, keyword_call=keyword_call)
+        assert skip_from_str == skip
+
+    @pytest.mark.parametrize(
+        "skip_config, names, disabled",
+        [
+            ("executejavascript", ["Execute Javascript"], [True]),
+            ("executejavascript", ["OtherLib.Execute Javascript"], [False]),
+            ("executejavascript", ["Keyword"], [False]),
+            ("Execute_Javascript", ["Keyword", "Execute_Javas cript"], [False, True]),
+            ("executejavascript", [None], [False]),
+            (None, ["Execute Javascript"], [False]),
+            (
+                "executejavascript,otherkeyword",
+                ["Execute Javascript", "Test Keyword", "Other_keyword"],
+                [True, False, True],
+            ),
+        ],
+    )
+    def test_skip_keyword_call(self, skip_config, names, disabled):
+        mock_node = Mock()
+        skip_config = SkipConfig.from_str_config(global_skip=SkipConfig(), keyword_call=skip_config)
+        skip = Skip(skip_config=skip_config)
+        for name, disable in zip(names, disabled):
+            mock_node.keyword = name
+            assert disable == skip.keyword_call(mock_node)
+
+    @pytest.mark.parametrize(
+        "skip_config, names, disabled",
+        [
+            ("Execute Javascript", ["Execute Javascript"], [True]),
+            ("Execute Javascript", ["executejavascript"], [False]),
+            ("(?i)execute\s?javascript", ["Execute Javascript"], [True]),
+            ("executejavascript", ["Keyword"], [False]),
+            ("Javascript", ["Execute Javascript"], [True]),
+            ("^Javascript", ["Execute Javascript"], [False]),
+            ("Execute", ["Execute Javascript"], [True]),
+            ("Execute1", ["Execute Javascript"], [False]),
+            ("Execute", ["Execute Javascript", "Execute Other Stuff", "Keyword"], [True, True, False]),
+            (
+                "(?i)Library\.",
+                ["Library.Stuff", "Library2.Stuff", "library.Other_stuff", "library"],
+                [True, False, True, False],
+            ),
+            ("(?i)execute,javascript", ["Execute", "Quasadilla", "Javascript"], [True, False, False]),
+            (None, ["Execute Javascript"], [False]),
+            ("executejavascript", [None], [False]),
+        ],
+    )
+    def test_skip_keyword_call_pattern(self, skip_config, names, disabled):
+        mock_node = Mock()
+        skip_config = SkipConfig.from_str_config(global_skip=SkipConfig(), keyword_call_pattern=skip_config)
+        skip = Skip(skip_config=skip_config)
+        for name, disable in zip(names, disabled):
+            mock_node.keyword = name
+            assert disable == skip.keyword_call(mock_node)
+
+    def test_keyword_call_pattern_invalid(self):
+        invalid_regex = "[0-9]++"
+        skip_config = SkipConfig(keyword_call_pattern=[invalid_regex])
+        msg_error = re.escape(f"'{invalid_regex}' is not a valid regular expression.")
+        with pytest.raises(ValueError, match=msg_error):
+            Skip(skip_config=skip_config)

--- a/tests/utest/test_utils.py
+++ b/tests/utest/test_utils.py
@@ -5,11 +5,13 @@ import pytest
 
 from robotidy.app import Robotidy
 from robotidy.config import Config, FormattingConfig
+from robotidy.disablers import SkipConfig
 from robotidy.utils import ROBOT_VERSION, decorate_diff_with_color, split_args_from_name_or_path
 
 
 @pytest.fixture
 def app():
+    skip_config = SkipConfig()
     formatting_config = FormattingConfig(
         space_count=4,
         indent=4,
@@ -23,6 +25,7 @@ def app():
     config = Config(
         transformers=[],
         transformers_config=[],
+        skip=skip_config,
         src=(".",),
         exclude=None,
         extend_exclude=None,


### PR DESCRIPTION
Closes #310 

Last part of the skip feature - allow to skip formatting globally. 

It's possible to define skips from cli:

```
robotidy --skip-documentation src
```
skip_documentation will apply to all transformers that support this option. If both global and local arguments are provided, the local is overriding global:
```
robotidy --skip-documentation NormalizeSeparators:skip_documentation=False src
```