### PR TITLE
Split too long lines in Align Test Case / Keyword Section transformers

### DIFF
--- a/docs/source/configuration/skip_formatting.rst
+++ b/docs/source/configuration/skip_formatting.rst
@@ -37,7 +37,7 @@ Both options are configurable using configuration file (:ref:`config-file`).
         "NormalizeSeparators:skip_documentation=False"
     ]
 
-.. _skip return_values:
+.. _skip return values:
 
 Skip return values
 -------------------

--- a/docs/source/transformers/AlignKeywordsSection.rst
+++ b/docs/source/transformers/AlignKeywordsSection.rst
@@ -11,6 +11,53 @@ Short description.
 
 Long description with code examples.
 
+Split too long lines
+---------------------
+``AlignKeywordsSection`` will split the lines if the lines after alignment would exceed the limits set in
+the :ref:`SplitTooLongLine` transformer.
+
+.. note::
+    Currently only ``--configure SplitTooLongLine:split_on_every_arg=True`` mode is supported.
+
+Using this configuration (``SplitTooLongLine`` is enabled by default)::
+
+    robotidy -c AlignTestCasesSection:enabled=True:widths=14,24 --line-length 80 src
+
+Will result in the following transformation:
+
+.. tabs::
+
+    .. code-tab:: robotframework Before
+
+        *** Test Cases ***
+        Test case
+            # fits now but it will not fit after the alignment
+            Keyword    argument1    argument2    argument3    argument4
+
+            # does not fit before alignment
+            Longer Keyword Name That Could Happen    argument value with sentence that goes over
+
+            # fits, will not be split
+            Keyword    argument
+
+    .. code-tab:: robotframework After
+
+        *** Test Cases ***
+        Test case
+            # fits now but it will not fit after the alignment
+            Keyword
+            ...           argument1
+            ...           argument2
+            ...           argument3
+            ...           argument4
+
+            # does not fit before alignment
+            Longer Keyword Name That Could Happen
+            ...           argument value with sentence that goes over
+
+            # fits, will be aligned but not split
+            Keyword       argument
+
 Skip formatting
 ----------------
 It is possible to use the following arguments to skip formatting of the code:

--- a/docs/source/transformers/AlignKeywordsSection.rst
+++ b/docs/source/transformers/AlignKeywordsSection.rst
@@ -13,17 +13,17 @@ Long description with code examples.
 
 Split too long lines
 ---------------------
-``AlignKeywordsSection`` will split the lines if the lines after alignment would exceed the limits set in
-the :ref:`SplitTooLongLine` transformer.
+``AlignKeywordsSection`` will split the lines if the lines after the alignment would exceed the limits set
+in the :ref:`SplitTooLongLine` transformer.
 
 .. note::
-    Currently only ``--configure SplitTooLongLine:split_on_every_arg=True`` mode is supported.
+    Currently, only ``--configure SplitTooLongLine:split_on_every_arg=True`` mode is supported.
 
 Using this configuration (``SplitTooLongLine`` is enabled by default)::
 
     robotidy -c AlignTestCasesSection:enabled=True:widths=14,24 --line-length 80 src
 
-Will result in the following transformation:
+will result in the following transformation:
 
 .. tabs::
 
@@ -34,7 +34,7 @@ Will result in the following transformation:
             # fits now but it will not fit after the alignment
             Keyword    argument1    argument2    argument3    argument4
 
-            # does not fit before alignment
+            # does not fit before the alignment
             Longer Keyword Name That Could Happen    argument value with sentence that goes over
 
             # fits, will not be split
@@ -51,7 +51,7 @@ Will result in the following transformation:
             ...           argument3
             ...           argument4
 
-            # does not fit before alignment
+            # does not fit before the alignment
             Longer Keyword Name That Could Happen
             ...           argument value with sentence that goes over
 

--- a/docs/source/transformers/AlignTestCasesSection.rst
+++ b/docs/source/transformers/AlignTestCasesSection.rst
@@ -11,6 +11,54 @@ Short description.
 
 Long description with code examples.
 
+Split too long lines
+---------------------
+``AlignKeywordsSection`` will split the lines if the lines after alignment would exceed the limits set in
+the :ref:`SplitTooLongLine` transformer.
+
+.. note::
+    Currently only ``--configure SplitTooLongLine:split_on_every_arg=True`` mode is supported.
+
+Using this configuration (``SplitTooLongLine`` is enabled by default)::
+
+    robotidy -c AlignTestCasesSection:enabled=True:widths=14,24 --line-length 80 src
+
+Will result in the following transformation:
+
+.. tabs::
+
+    .. code-tab:: robotframework Before
+
+        *** Test Cases ***
+        Test case
+            # fits now but it will not fit after the alignment
+            Keyword    argument1    argument2    argument3    argument4
+
+            # does not fit before alignment
+            Longer Keyword Name That Could Happen    argument value with sentence that goes over
+
+            # fits, will not be split
+            Keyword    argument
+
+    .. code-tab:: robotframework After
+
+        *** Test Cases ***
+        Test case
+            # fits now but it will not fit after the alignment
+            Keyword
+            ...           argument1
+            ...           argument2
+            ...           argument3
+            ...           argument4
+
+            # does not fit before alignment
+            Longer Keyword Name That Could Happen
+            ...           argument value with sentence that goes over
+
+            # fits, will be aligned but not split
+            Keyword       argument
+
+
 Skip formatting
 ----------------
 It is possible to use the following arguments to skip formatting of the code:

--- a/docs/source/transformers/AlignTestCasesSection.rst
+++ b/docs/source/transformers/AlignTestCasesSection.rst
@@ -13,17 +13,17 @@ Long description with code examples.
 
 Split too long lines
 ---------------------
-``AlignKeywordsSection`` will split the lines if the lines after alignment would exceed the limits set in
-the :ref:`SplitTooLongLine` transformer.
+``AlignKeywordsSection`` will split the lines if the lines after the alignment would exceed the limits set
+in the :ref:`SplitTooLongLine` transformer.
 
 .. note::
-    Currently only ``--configure SplitTooLongLine:split_on_every_arg=True`` mode is supported.
+    Currently, only ``--configure SplitTooLongLine:split_on_every_arg=True`` mode is supported.
 
 Using this configuration (``SplitTooLongLine`` is enabled by default)::
 
     robotidy -c AlignTestCasesSection:enabled=True:widths=14,24 --line-length 80 src
 
-Will result in the following transformation:
+will result in the following transformation:
 
 .. tabs::
 
@@ -34,7 +34,7 @@ Will result in the following transformation:
             # fits now but it will not fit after the alignment
             Keyword    argument1    argument2    argument3    argument4
 
-            # does not fit before alignment
+            # does not fit before the alignment
             Longer Keyword Name That Could Happen    argument value with sentence that goes over
 
             # fits, will not be split
@@ -51,7 +51,7 @@ Will result in the following transformation:
             ...           argument3
             ...           argument4
 
-            # does not fit before alignment
+            # does not fit before the alignment
             Longer Keyword Name That Could Happen
             ...           argument value with sentence that goes over
 

--- a/robotidy/config.py
+++ b/robotidy/config.py
@@ -84,9 +84,11 @@ class Config:
         self.transformers = load_transformers(
             transformers, transformers_config, force_order=force_order, target_version=target_version, skip=skip
         )
+        transformer_map = {transformer.__class__.__name__: transformer for transformer in self.transformers}
         for transformer in self.transformers:
             # inject global settings TODO: handle it better
             setattr(transformer, "formatting_config", self.formatting)
+            setattr(transformer, "transformers", transformer_map)
 
     @staticmethod
     def convert_configure(configure: List[Tuple[str, List]]) -> Dict[str, List]:

--- a/robotidy/transformers/__init__.py
+++ b/robotidy/transformers/__init__.py
@@ -9,7 +9,7 @@ If you don't want to run your transformer by default and only when calling robot
 then add ``ENABLED = False`` class attribute inside.
 """
 from itertools import chain
-from typing import Optional
+from typing import Dict, Optional
 
 try:
     import rich_click as click
@@ -61,6 +61,7 @@ IMPORTER = Importer()
 class Transformer(ModelTransformer):
     def __init__(self, skip: Optional[Skip] = None):
         self.formatting_config = None  # to make lint happy (we're injecting the configs)
+        self.transformers: Dict = dict()
         self.disablers = None
         self.skip = skip
 

--- a/tests/atest/transformers/AlignKeywordsSection/expected/simple_auto_ignore_line_4_4_4.robot
+++ b/tests/atest/transformers/AlignKeywordsSection/expected/simple_auto_ignore_line_4_4_4.robot
@@ -1,0 +1,17 @@
+*** Keywords ***
+Keyword
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short    Short    Short
+    Single
+    Multi    ${arg}
+    ...    ${arg}
+
+Second Keyword
+    Looooooooonger Keyword Name
+
+With Comments
+    Single  # comment 1
+    With Arg  # comment 2  comment 3
+    Multi    ${arg}  # comment 4
+    ...    ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/atest/transformers/AlignKeywordsSection/expected/simple_fixed_ignore_line_4_4_4.robot
+++ b/tests/atest/transformers/AlignKeywordsSection/expected/simple_fixed_ignore_line_4_4_4.robot
@@ -1,0 +1,17 @@
+*** Keywords ***
+Keyword
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short    Short    Short
+    Single
+    Multi    ${arg}
+    ...    ${arg}
+
+Second Keyword
+    Looooooooonger Keyword Name
+
+With Comments
+    Single  # comment 1
+    With Arg  # comment 2  comment 3
+    Multi    ${arg}  # comment 4
+    ...    ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/atest/transformers/AlignKeywordsSection/expected/skip_keywords.robot
+++ b/tests/atest/transformers/AlignKeywordsSection/expected/skip_keywords.robot
@@ -18,3 +18,5 @@ Exclude whole multiline case by rule "Should_Not_Be_None"
     ...                     ${ASIAKAS}              ${ASIAKAS_ID}           ${LÄHETYSOSOITE}        ${LÄHETYSTAPA}          ${LASKUTUSOSOITE}
     ...                     ${LIIKEYKSIKKÖ}         ${TILAAJA}              tila_tilaus=Käsittelyssä                        tila_tilausrivi=Odottaa lähetystä
     ...                     lähde=${LÄHDE}          hinta_yks=${HINTA_YKSI}                         hinta_rivi=${HINTA_RIVI}
+
+    ${HINTA_YKSI}    ${HINTA_RIVI}    ${HINTA_TILAUS_ALV}    ${toimituspvm}    TiHa_MyyntitilausTarkista_Tiedot

--- a/tests/atest/transformers/AlignKeywordsSection/expected/too_long_line.robot
+++ b/tests/atest/transformers/AlignKeywordsSection/expected/too_long_line.robot
@@ -1,0 +1,16 @@
+*** Keywords ***
+Many arguments
+    # fits without alignment
+    Keyword    argument1    argument2    argument3    argument4    argument5    argument6    argument7    argument8
+
+    # does not fit before alignment
+    Longer Keyword Name That Could Happen In Real Life Too    argument value with sentence that goes over the characters limit
+
+    # multiline but fits without alignment
+    Keyword
+    ...    arg
+    ...    argument1    argument2    argument3    argument4    argument5    argument6    argument7    argument8
+
+Many assignments
+    ${longer_argument}    ${longer_argument2}    ${longer_argument3}    ${longer_argument4}    ${longer_argument5}    ${longer_argument6}    Keyword
+    ...    argument1    argument2

--- a/tests/atest/transformers/AlignKeywordsSection/expected/too_long_line.robot
+++ b/tests/atest/transformers/AlignKeywordsSection/expected/too_long_line.robot
@@ -1,16 +1,39 @@
 *** Keywords ***
 Many arguments
     # fits without alignment
-    Keyword    argument1    argument2    argument3    argument4    argument5    argument6    argument7    argument8
+    Keyword
+    ...                     argument1
+    ...                     argument2
+    ...                     argument3
+    ...                     argument4
+    ...                     argument5
+    ...                     argument6
+    ...                     argument7
+    ...                     argument8
 
     # does not fit before alignment
-    Longer Keyword Name That Could Happen In Real Life Too    argument value with sentence that goes over the characters limit
+    Longer Keyword Name That Could Happen In Real Life Too
+    ...                     argument value with sentence that goes over the characters limit
 
     # multiline but fits without alignment
     Keyword
-    ...    arg
-    ...    argument1    argument2    argument3    argument4    argument5    argument6    argument7    argument8
+    ...                     arg
+    ...                     argument1
+    ...                     argument2
+    ...                     argument3
+    ...                     argument4
+    ...                     argument5
+    ...                     argument6
+    ...                     argument7
+    ...                     argument8
 
 Many assignments
-    ${longer_argument}    ${longer_argument2}    ${longer_argument3}    ${longer_argument4}    ${longer_argument5}    ${longer_argument6}    Keyword
-    ...    argument1    argument2
+    ${longer_argument}
+    ...                     ${longer_argument2}
+    ...                     ${longer_argument3}
+    ...                     ${longer_argument4}
+    ...                     ${longer_argument5}
+    ...                     ${longer_argument6}
+    ...                     Keyword
+    ...                     argument1
+    ...                     argument2

--- a/tests/atest/transformers/AlignKeywordsSection/source/error_node.robot
+++ b/tests/atest/transformers/AlignKeywordsSection/source/error_node.robot
@@ -1,0 +1,5 @@
+*** Keywords ***
+Missing keyword call
+    WHILE    $condition
+        ${var}
+    END

--- a/tests/atest/transformers/AlignKeywordsSection/source/skip_keywords.robot
+++ b/tests/atest/transformers/AlignKeywordsSection/source/skip_keywords.robot
@@ -18,3 +18,5 @@ Exclude whole multiline case by rule "Should_Not_Be_None"
     ...                     ${ASIAKAS}                  ${ASIAKAS_ID}       ${LÄHETYSOSOITE}    ${LÄHETYSTAPA}      ${LASKUTUSOSOITE}
     ...                     ${LIIKEYKSIKKÖ}             ${TILAAJA}          tila_tilaus=Käsittelyssä                tila_tilausrivi=Odottaa lähetystä
     ...                     lähde=${LÄHDE}              hinta_yks=${HINTA_YKSI}                 hinta_rivi=${HINTA_RIVI}
+
+    ${HINTA_YKSI}  ${HINTA_RIVI}  ${HINTA_TILAUS_ALV}  ${toimituspvm}    TiHa_MyyntitilausTarkista_Tiedot

--- a/tests/atest/transformers/AlignKeywordsSection/source/too_long_line.robot
+++ b/tests/atest/transformers/AlignKeywordsSection/source/too_long_line.robot
@@ -1,0 +1,16 @@
+*** Keywords ***
+Many arguments
+    # fits without alignment
+    Keyword    argument1    argument2    argument3    argument4    argument5    argument6    argument7    argument8
+
+    # does not fit before alignment
+    Longer Keyword Name That Could Happen In Real Life Too    argument value with sentence that goes over the characters limit
+
+    # multiline but fits without alignment
+    Keyword
+    ...    arg
+    ...    argument1    argument2    argument3    argument4    argument5    argument6    argument7    argument8
+
+Many assignments
+    ${longer_argument}    ${longer_argument2}    ${longer_argument3}    ${longer_argument4}    ${longer_argument5}    ${longer_argument6}    Keyword
+    ...    argument1    argument2

--- a/tests/atest/transformers/AlignKeywordsSection/test_transformer.py
+++ b/tests/atest/transformers/AlignKeywordsSection/test_transformer.py
@@ -87,3 +87,6 @@ class TestAlignKeywordsSection(TransformerAcceptanceTest):
 
     def test_too_long_line(self):
         self.compare(source="too_long_line.robot", config=" --transform SplitTooLongLine")
+
+    def test_error_node(self):
+        self.compare(source="error_node.robot", not_modified=True)

--- a/tests/atest/transformers/AlignKeywordsSection/test_transformer.py
+++ b/tests/atest/transformers/AlignKeywordsSection/test_transformer.py
@@ -40,10 +40,6 @@ class TestAlignKeywordsSection(TransformerAcceptanceTest):
     @pytest.mark.parametrize("handle_too_long", ["overflow", "ignore_line", "ignore_rest"])
     @pytest.mark.parametrize("alignment_type", ["auto", "fixed"])
     def test_simple(self, alignment_type, handle_too_long, widths: Tuple):
-        if widths == (4, 4, 4) and handle_too_long == "ignore_line":
-            not_modified = True  # it will never fit, so all lines are ignored
-        else:
-            not_modified = False
         width_name = "_".join(str(width) for width in widths)
         if width_name == "0_0_0":
             width_name = "0"  # it should be the same result so we can reuse expected file
@@ -51,7 +47,7 @@ class TestAlignKeywordsSection(TransformerAcceptanceTest):
         expected = f"simple_{alignment_type}_{handle_too_long}_{width_name}.robot"
         config = f":alignment_type={alignment_type}:handle_too_long={handle_too_long}"
         config += f":widths={width_csv}"
-        self.compare(source="simple.robot", expected=expected, config=config, not_modified=not_modified)
+        self.compare(source="simple.robot", expected=expected, config=config)
 
     def test_settings(self):
         self.compare(source="settings.robot")
@@ -88,3 +84,7 @@ class TestAlignKeywordsSection(TransformerAcceptanceTest):
 
     def test_compact_overflow_last_0(self):
         self.compare(source="compact_overflow_last_0.robot", config=":widths=4,0")
+
+    #
+    # def test_too_long_line(self):
+    #     self.compare(source="too_long_line.robot")

--- a/tests/atest/transformers/AlignKeywordsSection/test_transformer.py
+++ b/tests/atest/transformers/AlignKeywordsSection/test_transformer.py
@@ -89,4 +89,4 @@ class TestAlignKeywordsSection(TransformerAcceptanceTest):
         self.compare(source="too_long_line.robot", config=" --transform SplitTooLongLine")
 
     def test_error_node(self):
-        self.compare(source="error_node.robot", not_modified=True)
+        self.compare(source="error_node.robot", not_modified=True, target_version=5)

--- a/tests/atest/transformers/AlignKeywordsSection/test_transformer.py
+++ b/tests/atest/transformers/AlignKeywordsSection/test_transformer.py
@@ -85,6 +85,5 @@ class TestAlignKeywordsSection(TransformerAcceptanceTest):
     def test_compact_overflow_last_0(self):
         self.compare(source="compact_overflow_last_0.robot", config=":widths=4,0")
 
-    #
-    # def test_too_long_line(self):
-    #     self.compare(source="too_long_line.robot")
+    def test_too_long_line(self):
+        self.compare(source="too_long_line.robot", config=" --transform SplitTooLongLine")

--- a/tests/atest/transformers/AlignTestCasesSection/expected/simple_auto_ignore_line_4_4_4.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/expected/simple_auto_ignore_line_4_4_4.robot
@@ -1,0 +1,17 @@
+*** Test Cases ***
+Keyword
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short    Short    Short
+    Single
+    Multi    ${arg}
+    ...    ${arg}
+
+Second Keyword
+    Looooooooonger Keyword Name
+
+With Comments
+    Single  # comment 1
+    With Arg  # comment 2  comment 3
+    Multi    ${arg}  # comment 4
+    ...    ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/atest/transformers/AlignTestCasesSection/expected/simple_fixed_ignore_line_4_4_4.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/expected/simple_fixed_ignore_line_4_4_4.robot
@@ -1,0 +1,17 @@
+*** Test Cases ***
+Keyword
+    ${assign}    Looooooooonger Keyword Name    ${argument}
+    Short    Short    Short
+    Single
+    Multi    ${arg}
+    ...    ${arg}
+
+Second Keyword
+    Looooooooonger Keyword Name
+
+With Comments
+    Single  # comment 1
+    With Arg  # comment 2  comment 3
+    Multi    ${arg}  # comment 4
+    ...    ${arg}  # comment 5
+    Three Args    argument    argument

--- a/tests/atest/transformers/AlignTestCasesSection/expected/skip_keywords.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/expected/skip_keywords.robot
@@ -14,7 +14,13 @@ Exclude whole multiline case by rule "Should_Not_Be_None"
 
     ${HINTA_YKSI}    ${HINTA_RIVI}    ${HINTA_TILAUS_ALV}    ${toimituspvm}=
     ...                     TiHa_MyyntitilausTarkista_Tiedot
-    ...                     ${TILAUS_FUSION}        ${NIMIKE}               ${NIMIKEKUVAUS}         ${MÄÄRÄ}                ${MITTAYKSIKKÖ}         ${TILAUSPVM}
-    ...                     ${ASIAKAS}              ${ASIAKAS_ID}           ${LÄHETYSOSOITE}        ${LÄHETYSTAPA}          ${LASKUTUSOSOITE}
-    ...                     ${LIIKEYKSIKKÖ}         ${TILAAJA}              tila_tilaus=Käsittelyssä                        tila_tilausrivi=Odottaa lähetystä
-    ...                     lähde=${LÄHDE}          hinta_yks=${HINTA_YKSI}                         hinta_rivi=${HINTA_RIVI}
+    ...                     ${TILAUS_FUSION}        ${NIMIKE}               ${NIMIKEKUVAUS}             ${MÄÄRÄ}                    ${MITTAYKSIKKÖ}             ${TILAUSPVM}
+    ...                     ${ASIAKAS}              ${ASIAKAS_ID}           ${LÄHETYSOSOITE}            ${LÄHETYSTAPA}              ${LASKUTUSOSOITE}
+    ...                     ${LIIKEYKSIKKÖ}         ${TILAAJA}              tila_tilaus=Käsittelyssä    tila_tilausrivi=Odottaa lähetystä
+    ...                     lähde=${LÄHDE}          hinta_yks=${HINTA_YKSI}                             hinta_rivi=${HINTA_RIVI}
+
+    ${HINTA_YKSI}    ${HINTA_RIVI}    ${HINTA_TILAUS_ALV}    ${toimituspvm}    TiHa_MyyntitilausTarkista_Tiedot
+
+    ${one_assign}    Keyword                        ${multiple}             ${arguments}                ${should_be}                ${aligned}
+
+    ${assign}    ${two_assign_vars}    Keyword      ${multiple}             ${arguments}                ${should_be}                ${aligned}

--- a/tests/atest/transformers/AlignTestCasesSection/source/skip_keywords.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/source/skip_keywords.robot
@@ -18,3 +18,9 @@ Exclude whole multiline case by rule "Should_Not_Be_None"
     ...                     ${ASIAKAS}                  ${ASIAKAS_ID}       ${LÄHETYSOSOITE}    ${LÄHETYSTAPA}      ${LASKUTUSOSOITE}
     ...                     ${LIIKEYKSIKKÖ}             ${TILAAJA}          tila_tilaus=Käsittelyssä                tila_tilausrivi=Odottaa lähetystä
     ...                     lähde=${LÄHDE}              hinta_yks=${HINTA_YKSI}                 hinta_rivi=${HINTA_RIVI}
+
+    ${HINTA_YKSI}  ${HINTA_RIVI}  ${HINTA_TILAUS_ALV}  ${toimituspvm}    TiHa_MyyntitilausTarkista_Tiedot
+
+    ${one_assign}    Keyword    ${multiple}    ${arguments}    ${should_be}    ${aligned}
+
+    ${assign}    ${two_assign_vars}    Keyword          ${multiple}             ${arguments}            ${should_be}            ${aligned}

--- a/tests/atest/transformers/AlignTestCasesSection/test_transformer.py
+++ b/tests/atest/transformers/AlignTestCasesSection/test_transformer.py
@@ -40,10 +40,6 @@ class TestAlignTestCasesSection(TransformerAcceptanceTest):
     @pytest.mark.parametrize("handle_too_long", ["overflow", "ignore_line", "ignore_rest"])
     @pytest.mark.parametrize("alignment_type", ["auto", "fixed"])
     def test_simple(self, alignment_type, handle_too_long, widths: Tuple):
-        if widths == (4, 4, 4) and handle_too_long == "ignore_line":
-            not_modified = True  # it will never fit, so all lines are ignored
-        else:
-            not_modified = False
         width_name = "_".join(str(width) for width in widths)
         if width_name == "0_0_0":
             width_name = "0"  # it should be the same result so we can reuse expected file
@@ -51,7 +47,7 @@ class TestAlignTestCasesSection(TransformerAcceptanceTest):
         expected = f"simple_{alignment_type}_{handle_too_long}_{width_name}.robot"
         config = f":alignment_type={alignment_type}:handle_too_long={handle_too_long}"
         config += f":widths={width_csv}"
-        self.compare(source="simple.robot", expected=expected, config=config, not_modified=not_modified)
+        self.compare(source="simple.robot", expected=expected, config=config)
 
     def test_settings(self):
         self.compare(source="settings.robot")

--- a/tests/atest/transformers/AlignTestCasesSection/test_transformer.py
+++ b/tests/atest/transformers/AlignTestCasesSection/test_transformer.py
@@ -70,7 +70,8 @@ class TestAlignTestCasesSection(TransformerAcceptanceTest):
             "skip_keywords.robot",
             config=":skip_keyword_call=should_not_be_none"
             ":skip_keyword_call_pattern=Contain,^(?i)prefix"
-            ":skip_return_values=True",
+            ":skip_return_values=True"
+            ":widths=24,24,24,28",
         )
 
     @pytest.mark.parametrize("handle_too_long", ["overflow", "compact_overflow", "ignore_line", "ignore_rest"])


### PR DESCRIPTION
Aligners often aligned code over the line length specified in SplitTooLongLine transformer - but the latter replaced custom,aligned separator with fixed spacing and broke alignment. That's why this PR adds feature to split keyword calls by aligners if aligned line goes over character limit.
It's very useful feature - and to complete I needed to call one transformer from another (which wasn't feasible so far but now open new opportunities). Before every transformer was independent and it wasn't possible. 

Now AlignKeywordsSection and AlignTestCasesSection now check for line length and if it will exceed line length limit the keyword call will be split and then realigned again. This feature will be expanded in next releases (support for other alignes such as AlignSettingsSection or AlignVariablesSection, or splitting other statements than keyword calls, or other split mode than ``split_on_every_arg``).