### PR TITLE
Fix compact_overflow failing to align more than two too long columns

### DIFF
--- a/robotidy/transformers/aligners_core.py
+++ b/robotidy/transformers/aligners_core.py
@@ -303,8 +303,8 @@ class AlignKeywordsTestsSection(Transformer):
                     if self.handle_too_long == "ignore_rest":
                         return aligned + align_fixed(tokens[index + 1 :], separator)
                     if self.handle_too_long == "compact_overflow":
-                        required_width = round_to_four(len(token.value) + separator)
-                        separator_len = required_width - len(token.value)
+                        required_width = len(token.value) + separator + prev_overflow_len
+                        separator_len = separator
                         prev_overflow_len = required_width - width
                     else:  # "overflow"
                         while round_to_four(len(token.value) + separator) > width:

--- a/tests/atest/transformers/AlignKeywordsSection/expected/overflow_first_line.robot
+++ b/tests/atest/transformers/AlignKeywordsSection/expected/overflow_first_line.robot
@@ -1,15 +1,15 @@
 *** Keywords ***
 compact_overflow issue case
-    ${HINTA_YKSI}           ${HINTA_RIVI}               ${HINTA_TILAUS_ALV}     ${toimituspvm}=
+    ${HINTA_YKSI}           ${HINTA_RIVI}               ${HINTA_TILAUS_ALV}    ${toimituspvm}=
     ...                     TiHa_MyyntitilausTarkista_Tiedot
     ...                     ${TILAUS_FUSION}            ${NIMIKE}           ${NIMIKEKUVAUS}     ${MÄÄRÄ}            ${MITTAYKSIKKÖ}     ${TILAUSPVM}
     ...                     ${ASIAKAS}                  ${ASIAKAS_ID}       ${LÄHETYSOSOITE}    ${LÄHETYSTAPA}      ${LASKUTUSOSOITE}
     ...                     ${LIIKEYKSIKKÖ}             ${TILAAJA}          tila_tilaus=Käsittelyssä    tila_tilausrivi=Odottaa lähetystä
-    ...                     lähde=${LÄHDE}              hinta_yks=${HINTA_YKSI}     hinta_rivi=${HINTA_RIVI}
+    ...                     lähde=${LÄHDE}              hinta_yks=${HINTA_YKSI}    hinta_rivi=${HINTA_RIVI}
 
     RaAn_RaporttiTarkista_REP98
-    ...                     70 Procurement              RPOR LOG Ostoa odottavat rivit (REP98).xdo      HTML    ${LUONTIYKSIKKÖ}
-    ...                     ${LIIKEYKSIKKÖ}             ${TOIMITTAJA}       ${TOIMITTAJAN_TOIMIPAIKKA}      ${ASIAKASTYYPPI}    ${NIMIKETYYPPI}
+    ...                     70 Procurement              RPOR LOG Ostoa odottavat rivit (REP98).xdo    HTML    ${LUONTIYKSIKKÖ}
+    ...                     ${LIIKEYKSIKKÖ}             ${TOIMITTAJA}       ${TOIMITTAJAN_TOIMIPAIKKA}    ${ASIAKASTYYPPI}    ${NIMIKETYYPPI}
 
 compact_overflow OK working case
     Set Library Search Order    QWeb                    QMobile

--- a/tests/atest/transformers/AlignKeywordsSection/expected/too_long_token_counter_compact_overflow.robot
+++ b/tests/atest/transformers/AlignKeywordsSection/expected/too_long_token_counter_compact_overflow.robot
@@ -1,6 +1,6 @@
 *** Keywords ***
 Second Column Should Not Be Counted
-    I am too long to be counted     Do not count me
+    I am too long to be counted    Do not count me
     Short       Short       Short
     Longer
     ...         ${arg}      ${arg}

--- a/tests/atest/transformers/AlignTestCasesSection/expected/compact_overflow_bug.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/expected/compact_overflow_bug.robot
@@ -1,0 +1,6 @@
+*** Test Cases ***
+Test
+    VaHa_ValmiitTapahtumatTarkista_Osto    ${NIMIKE}    Ostotilaus          ${OSTOTILAUS}       ${MAARA}            ${ALIVARASTO}       varastopaika=${EMPTY}    tilauspvm=${TILAUSPVM}
+
+Test2
+    Lava_VastaanottotapahtumatTarkista    ${VASTAANOTTO}    ${TILAUS_OCC}    ${OSTOTILAUS}      ${LAHETYS}          ${TILAUSPVM}        ${NIMIKE}           ${NIMIKEKUVAUS}

--- a/tests/atest/transformers/AlignTestCasesSection/expected/overflow_first_line.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/expected/overflow_first_line.robot
@@ -1,15 +1,15 @@
 *** Test Cases ***
 compact_overflow issue case
-    ${HINTA_YKSI}           ${HINTA_RIVI}               ${HINTA_TILAUS_ALV}     ${toimituspvm}=
+    ${HINTA_YKSI}           ${HINTA_RIVI}               ${HINTA_TILAUS_ALV}    ${toimituspvm}=
     ...                     TiHa_MyyntitilausTarkista_Tiedot
     ...                     ${TILAUS_FUSION}            ${NIMIKE}           ${NIMIKEKUVAUS}     ${MÄÄRÄ}            ${MITTAYKSIKKÖ}     ${TILAUSPVM}
     ...                     ${ASIAKAS}                  ${ASIAKAS_ID}       ${LÄHETYSOSOITE}    ${LÄHETYSTAPA}      ${LASKUTUSOSOITE}
     ...                     ${LIIKEYKSIKKÖ}             ${TILAAJA}          tila_tilaus=Käsittelyssä    tila_tilausrivi=Odottaa lähetystä
-    ...                     lähde=${LÄHDE}              hinta_yks=${HINTA_YKSI}     hinta_rivi=${HINTA_RIVI}
+    ...                     lähde=${LÄHDE}              hinta_yks=${HINTA_YKSI}    hinta_rivi=${HINTA_RIVI}
 
     RaAn_RaporttiTarkista_REP98
-    ...                     70 Procurement              RPOR LOG Ostoa odottavat rivit (REP98).xdo      HTML    ${LUONTIYKSIKKÖ}
-    ...                     ${LIIKEYKSIKKÖ}             ${TOIMITTAJA}       ${TOIMITTAJAN_TOIMIPAIKKA}      ${ASIAKASTYYPPI}    ${NIMIKETYYPPI}
+    ...                     70 Procurement              RPOR LOG Ostoa odottavat rivit (REP98).xdo    HTML    ${LUONTIYKSIKKÖ}
+    ...                     ${LIIKEYKSIKKÖ}             ${TOIMITTAJA}       ${TOIMITTAJAN_TOIMIPAIKKA}    ${ASIAKASTYYPPI}    ${NIMIKETYYPPI}
 
 compact_overflow OK working case
     Set Library Search Order    QWeb                    QMobile

--- a/tests/atest/transformers/AlignTestCasesSection/expected/too_long_token_counter_compact_overflow.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/expected/too_long_token_counter_compact_overflow.robot
@@ -1,6 +1,6 @@
 *** Test Cases ***
 Second Column Should Not Be Counted
-    I am too long to be counted     Do not count me
+    I am too long to be counted    Do not count me
     Short       Short       Short
     Longer
     ...         ${arg}      ${arg}

--- a/tests/atest/transformers/AlignTestCasesSection/source/compact_overflow_bug.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/source/compact_overflow_bug.robot
@@ -1,0 +1,6 @@
+*** Test Cases ***
+Test
+    VaHa_ValmiitTapahtumatTarkista_Osto    ${NIMIKE}    Ostotilaus    ${OSTOTILAUS}    ${MAARA}    ${ALIVARASTO}    varastopaika=${EMPTY}    tilauspvm=${TILAUSPVM}
+
+Test2
+    Lava_VastaanottotapahtumatTarkista    ${VASTAANOTTO}    ${TILAUS_OCC}    ${OSTOTILAUS}    ${LAHETYS}    ${TILAUSPVM}    ${NIMIKE}    ${NIMIKEKUVAUS}

--- a/tests/atest/transformers/AlignTestCasesSection/test_transformer.py
+++ b/tests/atest/transformers/AlignTestCasesSection/test_transformer.py
@@ -88,3 +88,6 @@ class TestAlignTestCasesSection(TransformerAcceptanceTest):
 
     def test_templated(self):
         self.compare(source="templated.robot", not_modified=True)
+
+    def test_compact_overflow_bug(self):
+        self.compare(source="compact_overflow_bug.robot", config=":widths=24,28,20:handle_too_long=compact_overflow")


### PR DESCRIPTION
Small edge case: if several tokens in a row didn't fit in column, the ``prev_overflow_len`` didn't carry over. Example (of expected code) in the screenshot:

![image](https://user-images.githubusercontent.com/8532066/175650423-8f722976-8e67-478f-8850-683e0c66c1bc.png)

Now Robotidy carries over the overflow and will finally match with some of the next columns (in the screen it happens with ${LAHETYS} token).

Also removed rounding the separator and token to multiply of four for compact overflow. This is useful if you want to have alignment easy to tabulate into but with compact overflow it's probably not that necessary and it's causing lines to be wider.
