### PR TITLE
Skip formatting of setting

### DIFF
--- a/docs/source/configuration/skip_formatting.rst
+++ b/docs/source/configuration/skip_formatting.rst
@@ -34,7 +34,7 @@ Both options are configurable using configuration file (:ref:`config-file`).
     [tool.robotidy]
     skip-documentation = true
     configure = [
-        "NormalizeSeparators:skip_documentation=False"
+        "NormalizeSeparators : skip_documentation = False"
     ]
 
 .. _skip return values:
@@ -58,7 +58,7 @@ Both options are configurable using configuration file (:ref:`config-file`).
     [tool.robotidy]
     skip-return-values = true
     configure = [
-        "AlignKeywordsSection:skip_return_values=False"
+        "AlignKeywordsSection : skip_return_values = False"
     ]
 
 .. _skip keyword call:
@@ -90,7 +90,7 @@ Both options are configurable using configuration file (:ref:`config-file`).
         "supports spaces too"
     ]
     configure = [
-        "AlignKeywordsSection:skip_keyword_call=Name,othername"
+        "AlignKeywordsSection : skip_keyword_call = Name,othername"
     ]
 
 .. _skip keyword call pattern:
@@ -126,5 +126,54 @@ Both options are configurable using configuration file (:ref:`config-file`).
         "(i?)contains\s?words"
     ]
     configure = [
-        "AlignKeywordsSection:skip_keyword_call_pattern=first,secondname"
+        "AlignKeywordsSection : skip_keyword_call_pattern = first,secondname"
+    ]
+.. _skip settings:
+
+Skip settings
+-------------------
+Flag that disables formatting of the settings. Example usage::
+
+    robotidy -c AlignTestCasesSection:skip_settings=True src
+
+It is possible to use global flag to skip formatting for every transformer that supports it::
+
+    robotidy --skip-settings src
+
+Formatting of the settings can be also skip based on the type of the settings.
+The name of the option is ``skip_<setting_name>`` (for example ``skip_arguments``).
+Following types are possible to skip:
+
+- arguments - ``[Arguments]``
+- setup - ``[Setup]``
+- teardown - ``[Teardown]``
+- template - ``[Template]``
+- timeout - ``[Timeout]``
+- return - ``[Return]`` or ``RETURN``
+- tags - ``[Tags]``
+
+Configuration file
+~~~~~~~~~~~~~~~~~~~~
+Option is configurable using configuration file (:ref:`config-file`).
+
+Skip formatting of all settings:
+
+.. code-block:: toml
+
+    [tool.robotidy]
+    skip-settings = true
+    configure = [
+        "AlignTestCasesSection : skip_settings = False"
+    ]
+
+Skip formatting of selected settings:
+
+.. code-block:: toml
+
+    [tool.robotidy]
+    skip-setup = true
+    skip-teardown = true
+    configure = [
+        "AlignTestCasesSection : skip_setup = False"
+        "AlignKeywordsSection : skip_arguments = True"
     ]

--- a/docs/source/configuration/skip_formatting.rst
+++ b/docs/source/configuration/skip_formatting.rst
@@ -140,7 +140,7 @@ It is possible to use global flag to skip formatting for every transformer that 
 
     robotidy --skip-settings src
 
-Formatting of the settings can be also skip based on the type of the settings.
+Formatting of the settings can be also skipped based on the type of the settings.
 The name of the option is ``skip_<setting_name>`` (for example ``skip_arguments``).
 Following types are possible to skip:
 

--- a/docs/source/transformers/AlignKeywordsSection.rst
+++ b/docs/source/transformers/AlignKeywordsSection.rst
@@ -66,3 +66,4 @@ It is possible to use the following arguments to skip formatting of the code:
 - :ref:`skip return values`
 - :ref:`skip keyword call`
 - :ref:`skip keyword call pattern`
+- :ref:`skip settings`

--- a/docs/source/transformers/AlignTestCasesSection.rst
+++ b/docs/source/transformers/AlignTestCasesSection.rst
@@ -67,3 +67,4 @@ It is possible to use the following arguments to skip formatting of the code:
 - :ref:`skip return values`
 - :ref:`skip keyword call`
 - :ref:`skip keyword call pattern`
+- :ref:`skip settings`

--- a/robotidy/api.py
+++ b/robotidy/api.py
@@ -16,11 +16,27 @@ def get_skip_config(config):
     skip_return_values = config.get("skip_return_values", False)
     skip_keyword_call = config.get("skip_keyword_call", [])
     skip_keyword_call_pattern = config.get("skip_keyword_call_pattern", [])
+    skip_settings = config.get("skip_settings", False)
+    skip_arguments = config.get("skip_arguments", False)
+    skip_setup = config.get("skip_setup", False)
+    skip_teardown = config.get("skip_teardown", False)
+    skip_template = config.get("skip_template", False)
+    skip_timeout = config.get("skip_timeout", False)
+    skip_return = config.get("skip_return", False)
+    skip_tags = config.get("skip_tags", False)
     return SkipConfig(
         documentation=skip_documentation,
         return_values=skip_return_values,
         keyword_call=skip_keyword_call,
         keyword_call_pattern=skip_keyword_call_pattern,
+        settings=skip_settings,
+        arguments=skip_arguments,
+        setup=skip_setup,
+        teardown=skip_teardown,
+        template=skip_template,
+        timeout=skip_timeout,
+        return_statement=skip_return,
+        tags=skip_tags,
     )
 
 

--- a/robotidy/cli.py
+++ b/robotidy/cli.py
@@ -393,6 +393,14 @@ def print_transformers_list(target_version: int):
 @skip.return_values_option
 @skip.keyword_call_option
 @skip.keyword_call_pattern_option
+@skip.settings_option
+@skip.arguments_option
+@skip.setup_option
+@skip.teardown_option
+@skip.timeout_option
+@skip.template_option
+@skip.return_option
+@skip.tags_option
 @click.version_option(version=__version__, prog_name="robotidy")
 @click.pass_context
 @catch_exceptions
@@ -427,6 +435,14 @@ def cli(
     skip_return_values: bool,
     skip_keyword_call: List[str],
     skip_keyword_call_pattern: List[str],
+    skip_settings: bool,
+    skip_arguments: bool,
+    skip_setup: bool,
+    skip_teardown: bool,
+    skip_timeout: bool,
+    skip_template: bool,
+    skip_return: bool,
+    skip_tags: bool,
 ):
     """
     Robotidy is a tool for formatting Robot Framework source code.
@@ -463,6 +479,14 @@ def cli(
         return_values=skip_return_values,
         keyword_call=skip_keyword_call,
         keyword_call_pattern=skip_keyword_call_pattern,
+        settings=skip_settings,
+        arguments=skip_arguments,
+        setup=skip_setup,
+        teardown=skip_teardown,
+        template=skip_template,
+        timeout=skip_timeout,
+        return_statement=skip_return,
+        tags=skip_tags,
     )
 
     formatting = FormattingConfig(

--- a/robotidy/skip.py
+++ b/robotidy/skip.py
@@ -45,6 +45,14 @@ class SkipConfig:
             "skip_return_values",
             "skip_keyword_call",
             "skip_keyword_call_pattern",
+            "skip_settings",
+            "skip_arguments",
+            "skip_setup",
+            "skip_teardown",
+            "skip_timeout",
+            "skip_template",
+            "skip_return_statement",
+            "skip_tags",
         }
     )
 
@@ -54,11 +62,27 @@ class SkipConfig:
         return_values: bool = False,
         keyword_call: Optional[List] = None,
         keyword_call_pattern: Optional[List] = None,
+        settings: bool = False,
+        arguments: bool = False,
+        setup: bool = False,
+        teardown: bool = False,
+        timeout: bool = False,
+        template: bool = False,
+        return_statement: bool = False,
+        tags: bool = False,
     ):
         self.documentation = documentation
         self.return_values = return_values
         self.keyword_call: List = keyword_call if keyword_call else []
         self.keyword_call_pattern: List = keyword_call_pattern if keyword_call_pattern else []
+        self.settings = settings
+        self.arguments = arguments
+        self.setup = setup
+        self.teardown = teardown
+        self.timeout = timeout
+        self.template = template
+        self.return_statement = return_statement
+        self.tags = tags
 
     @classmethod
     def from_str_config(
@@ -68,10 +92,27 @@ class SkipConfig:
         return_values: Optional[str] = None,
         keyword_call: Optional[str] = None,
         keyword_call_pattern: Optional[str] = None,
+        settings: Optional[str] = None,
+        arguments: Optional[str] = None,
+        setup: Optional[str] = None,
+        teardown: Optional[str] = None,
+        timeout: Optional[str] = None,
+        template: Optional[str] = None,
+        return_statement: Optional[str] = None,
+        tags: Optional[str] = None,
     ):
         """Integrate local and global configurations into one (local takes precedence if specified)."""
+        # FIXME DRY
         documentation = join_optional_flag_with_global(documentation, global_skip.documentation)
         return_values = join_optional_flag_with_global(return_values, global_skip.return_values)
+        settings = join_optional_flag_with_global(settings, global_skip.settings)
+        arguments = join_optional_flag_with_global(arguments, global_skip.arguments)
+        setup = join_optional_flag_with_global(setup, global_skip.setup)
+        teardown = join_optional_flag_with_global(teardown, global_skip.teardown)
+        timeout = join_optional_flag_with_global(timeout, global_skip.timeout)
+        template = join_optional_flag_with_global(template, global_skip.template)
+        return_statement = join_optional_flag_with_global(return_statement, global_skip.return_statement)
+        tags = join_optional_flag_with_global(tags, global_skip.tags)
         keyword_call = join_optional_list_with_global(keyword_call, global_skip.keyword_call)
         keyword_call_pattern = join_optional_list_with_global(keyword_call_pattern, global_skip.keyword_call_pattern)
         return cls(
@@ -79,9 +120,17 @@ class SkipConfig:
             return_values=return_values,
             keyword_call=keyword_call,
             keyword_call_pattern=keyword_call_pattern,
+            settings=settings,
+            arguments=arguments,
+            setup=setup,
+            teardown=teardown,
+            timeout=timeout,
+            template=template,
+            return_statement=return_statement,
+            tags=tags,
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other):  # TODO remove or update
         return (
             self.documentation == other.documentation
             and self.return_values == other.return_values
@@ -99,6 +148,16 @@ class Skip:
         self.keyword_call_names = {normalize_name(name) for name in skip_config.keyword_call}
         self.keyword_call_pattern = {validate_regex(pattern) for pattern in skip_config.keyword_call_pattern}
         self.any_keword_call = self.check_any_keyword_call()
+        self.skip_settings = self.parse_skip_settings(skip_config)
+
+    @staticmethod
+    def parse_skip_settings(skip_config):
+        settings = {"settings", "arguments", "setup", "teardown", "timeout", "template", "return_statement", "tags"}
+        skip_settings = set()
+        for setting in settings:
+            if getattr(skip_config, setting):
+                skip_settings.add(setting)
+        return skip_settings
 
     def check_any_keyword_call(self):
         return self.keyword_call_names or self.keyword_call_pattern
@@ -113,6 +172,13 @@ class Skip:
             if pattern.search(node.keyword):
                 return True
         return False
+
+    def setting(self, name):
+        if not self.skip_settings:
+            return False
+        if "settings" in self.skip_settings:
+            return True
+        return name.lower() in self.skip_settings
 
 
 documentation_option = click.option(
@@ -137,7 +203,56 @@ keyword_call_pattern_option = click.option(
     multiple=True,
     help="Keyword call name pattern that should not be formatted",
 )
+settings_option = click.option("--skip-settings", is_flag=True, help="Skip formatting of settings")
+arguments_option = click.option(
+    "--skip-arguments",
+    is_flag=True,
+    help="Skip formatting of arguments",
+)
+setup_option = click.option(
+    "--skip-setup",
+    is_flag=True,
+    help="Skip formatting of setup",
+)
+teardown_option = click.option(
+    "--skip-teardown",
+    is_flag=True,
+    help="Skip formatting of teardown",
+)
+timeout_option = click.option(
+    "--skip-timeout",
+    is_flag=True,
+    help="Skip formatting of timeout",
+)
+template_option = click.option(
+    "--skip-template",
+    is_flag=True,
+    help="Skip formatting of template",
+)
+return_option = click.option(
+    "--skip-return",
+    is_flag=True,
+    help="Skip formatting of return statement",
+)
+tags_option = click.option(
+    "--skip-tags",
+    is_flag=True,
+    help="Skip formatting of tags",
+)
 option_group = {
     "name": "Skip formatting",
-    "options": ["--skip-documentation", "--skip-return-values", "--skip-keyword-call", "--skip-keyword-call-pattern"],
+    "options": [
+        "--skip-documentation",
+        "--skip-return-values",
+        "--skip-keyword-call",
+        "--skip-keyword-call-pattern",
+        "--skip-settings",
+        "--skip-arguments",
+        "--skip-setup",
+        "--skip-teardown",
+        "--skip-timeout",
+        "--skip-template",
+        "--skip-return",
+        "--skip-tags",
+    ],
 }

--- a/robotidy/transformers/AlignKeywordsSection.py
+++ b/robotidy/transformers/AlignKeywordsSection.py
@@ -9,9 +9,35 @@ from robotidy.transformers.aligners_core import AlignKeywordsTestsSection
 
 class AlignKeywordsSection(AlignKeywordsTestsSection):
     """
-    Short description in one line.
+    Align ``*** Keywords ***`` section to columns.
 
-    Long description with short example before/after.
+    Align keyword calls and settings into columns with predefined width. There are two possible alignment types
+    (configurable via ``alignment_type``):
+      - ``fixed`` (default): pad the tokens to the fixed width of the column
+      - ``auto``: pad the tokens to the width of the longest token in the column
+
+    Example output:
+    ```robotframework
+    *** Keywords ***
+    Keyword
+        ${var}        Create Resource       ${argument}       value
+        Assert        value
+        Multi
+        ...           line
+        ...           args
+    ```
+
+    Column widths can be configured via ``widths`` (default ``24``). It accepts comma separated list of column widths.
+
+    Tokens that are longer than width of the column go into "overflow" state. It's possible to decide in this
+    situation (by configuring ``handle_too_long``):
+      - ``overflow`` (default): align token to the next column
+      - ``compact_overflow``: try to fit next token between current (overflowed) token and next column
+      - ``ignore_rest``: ignore remaining tokens in the line
+      - ``ignore_line``: ignore whole line
+
+    It is possible to skip formatting on various types of the syntax (documentation, keyword calls with specific names
+    or settings).
     """
 
     def __init__(

--- a/robotidy/transformers/AlignTestCasesSection.py
+++ b/robotidy/transformers/AlignTestCasesSection.py
@@ -10,9 +10,35 @@ from robotidy.utils import is_suite_templated
 
 class AlignTestCasesSection(AlignKeywordsTestsSection):
     """
-    Short description in one line.
+    Align ``*** Test Cases ***`` section to columns.
 
-    Long description with short example before/after.
+    Align non-templated tests and settings into columns with predefined width. There are two possible alignment types
+    (configurable via ``alignment_type``):
+      - ``fixed`` (default): pad the tokens to the fixed width of the column
+      - ``auto``: pad the tokens to the width of the longest token in the column
+
+    Example output:
+    ```robotframework
+    *** Test Cases ***
+    Keyword
+        ${var}        Create Resource       ${argument}       value
+        Assert        value
+        Multi
+        ...           line
+        ...           args
+    ```
+
+    Column widths can be configured via ``widths`` (default ``24``). It accepts comma separated list of column widths.
+
+    Tokens that are longer than width of the column go into "overflow" state. It's possible to decide in this
+    situation (by configuring ``handle_too_long``):
+      - ``overflow`` (default): align token to the next column
+      - ``compact_overflow``: try to fit next token between current (overflowed) token and next column
+      - ``ignore_rest``: ignore remaining tokens in the line
+      - ``ignore_line``: ignore whole line
+
+    It is possible to skip formatting on various types of the syntax (documentation, keyword calls with specific names
+    or settings).
     """
 
     def __init__(

--- a/robotidy/transformers/aligners_core.py
+++ b/robotidy/transformers/aligners_core.py
@@ -11,7 +11,7 @@ except ImportError:
 from robotidy.disablers import Skip, skip_if_disabled
 from robotidy.exceptions import InvalidParameterValueError
 from robotidy.transformers import Transformer
-from robotidy.utils import is_blank_multiline, join_tokens_with_token, round_to_four, tokens_by_lines
+from robotidy.utils import is_blank_multiline, round_to_four, tokens_by_lines
 
 
 class AlignKeywordsTestsSection(Transformer):
@@ -19,7 +19,20 @@ class AlignKeywordsTestsSection(Transformer):
     ENABLED = False
     DEFAULT_WIDTH = 24
     HANDLES_SKIP = frozenset(
-        {"skip_documentation", "skip_return_values", "skip_keyword_call", "skip_keyword_call_pattern"}
+        {
+            "skip_documentation",
+            "skip_return_values",
+            "skip_keyword_call",
+            "skip_keyword_call_pattern",
+            "skip_settings",
+            "skip_arguments",
+            "skip_setup",
+            "skip_teardown",
+            "skip_template",
+            "skip_timeout",
+            "skip_return",
+            "skip_tags",
+        }
     )
 
     def __init__(
@@ -150,7 +163,7 @@ class AlignKeywordsTestsSection(Transformer):
             return self.formatting_config.space_count
         return width
 
-    def visit_SettingSection(self, node):  # do the same for test case section in keywords alignment etc
+    def visit_SettingSection(self, node):  # noqa
         return node
 
     @skip_if_disabled
@@ -216,12 +229,6 @@ class AlignKeywordsTestsSection(Transformer):
             return node
         return self.align_node(node, check_length=self.split_too_long)
 
-    @skip_if_disabled
-    def visit_Tags(self, node):  # noqa
-        if node.errors:
-            return node
-        return self.align_node(node, check_length=False)
-
     def align_node(self, node, check_length):
         lines = list(tokens_by_lines(node))
         indent = Token(Token.SEPARATOR, self.indent * self.formatting_config.indent)
@@ -236,7 +243,49 @@ class AlignKeywordsTestsSection(Transformer):
             aligned_lines.extend(aligned_line)
         return Statement.from_tokens(aligned_lines)
 
-    visit_Arguments = visit_Setup = visit_Teardown = visit_Timeout = visit_Template = visit_Return = visit_Tags
+    @skip_if_disabled
+    def visit_Tags(self, node):  # noqa
+        if node.errors or self.skip.setting("Tags"):
+            return node
+        return self.align_node(node, check_length=False)
+
+    @skip_if_disabled
+    def visit_Return(self, node):  # noqa
+        if node.errors or self.skip.setting("Return_Statement"):
+            return node
+        return self.align_node(node, check_length=False)
+
+    visit_ReturnStatement = visit_Return
+
+    @skip_if_disabled
+    def visit_Template(self, node):  # noqa
+        if node.errors or self.skip.setting("Template"):
+            return node
+        return self.align_node(node, check_length=False)
+
+    @skip_if_disabled
+    def visit_Timeout(self, node):  # noqa
+        if node.errors or self.skip.setting("Timeout"):
+            return node
+        return self.align_node(node, check_length=False)
+
+    @skip_if_disabled
+    def visit_Teardown(self, node):  # noqa
+        if node.errors or self.skip.setting("Teardown"):
+            return node
+        return self.align_node(node, check_length=False)
+
+    @skip_if_disabled
+    def visit_Setup(self, node):  # noqa
+        if node.errors or self.skip.setting("Setup"):
+            return node
+        return self.align_node(node, check_length=False)
+
+    @skip_if_disabled
+    def visit_Arguments(self, node):  # noqa
+        if node.errors or self.skip.setting("Arguments"):
+            return node
+        return self.align_node(node, check_length=False)
 
     def align_line(self, line, indent):
         """

--- a/tests/atest/transformers/AlignKeywordsSection/expected/skip_settings.robot
+++ b/tests/atest/transformers/AlignKeywordsSection/expected/skip_settings.robot
@@ -2,8 +2,8 @@
 Keyword With Settings
     [Documentation]  Docs should be left alone
     ...  even misaligned.
-    [Arguments]             ${args}                 ${args}  # comment
-    [Teardown]              Keyword
+    [Arguments]  ${args}  ${args}    # comment
+    [Teardown]  Keyword
     [Timeout]  1min
     Short
     Keyword Arg             ${arg}

--- a/tests/atest/transformers/AlignKeywordsSection/test_transformer.py
+++ b/tests/atest/transformers/AlignKeywordsSection/test_transformer.py
@@ -50,7 +50,11 @@ class TestAlignKeywordsSection(TransformerAcceptanceTest):
         self.compare(source="simple.robot", expected=expected, config=config)
 
     def test_settings(self):
-        self.compare(source="settings.robot")
+        self.compare(source="settings.robot", config=":skip_timeout=True")
+
+    def test_skip_settings(self):
+        self.compare(source="settings.robot", expected="skip_settings.robot", config=":skip_settings=True")
+        self.compare(source="settings.robot", expected="skip_settings.robot", config=" --skip-settings")
 
     def test_compact_overflow_first_line(self):
         self.compare(source="overflow_first_line.robot", config=":widths=24,28,20,20:handle_too_long=compact_overflow")
@@ -69,7 +73,7 @@ class TestAlignKeywordsSection(TransformerAcceptanceTest):
         self.compare(
             "skip_keywords.robot",
             config=":skip_keyword_call=should_not_be_none"
-            ":skip_keyword_call_pattern=Contain,^(?i)prefix"
+            ":skip_keyword_call_pattern=Contain,(?i)^prefix"
             ":skip_return_values=True",
         )
 

--- a/tests/atest/transformers/AlignTestCasesSection/test_transformer.py
+++ b/tests/atest/transformers/AlignTestCasesSection/test_transformer.py
@@ -69,7 +69,7 @@ class TestAlignTestCasesSection(TransformerAcceptanceTest):
         self.compare(
             "skip_keywords.robot",
             config=":skip_keyword_call=should_not_be_none"
-            ":skip_keyword_call_pattern=Contain,^(?i)prefix"
+            ":skip_keyword_call_pattern=Contain,(?i)^prefix"
             ":skip_return_values=True"
             ":widths=24,24,24,28",
         )

--- a/tests/utest/test_cli.py
+++ b/tests/utest/test_cli.py
@@ -8,6 +8,7 @@ from click import FileError, NoSuchOption
 from robotidy.api import Robotidy
 from robotidy.cli import read_config, validate_regex
 from robotidy.files import DEFAULT_EXCLUDES, find_project_root, get_paths, read_pyproject_config
+from robotidy.transformers.aligners_core import AlignKeywordsTestsSection
 from robotidy.transformers.AlignSettingsSection import AlignSettingsSection
 from robotidy.utils import ROBOT_VERSION
 
@@ -86,10 +87,9 @@ class TestCli:
             "alignment_type",
             "handle_too_long",
             "skip_documentation",
-            "skip_keyword_call",
-            "skip_keyword_call_pattern",
-            "skip_return_values",
         ]
+        # skip_documentation is overriden in transformer - the order is different because of that
+        expected_args += sorted(AlignKeywordsTestsSection.HANDLES_SKIP - {"skip_documentation"})
         expected_args_str = "\n    ".join(expected_args)
         expected_output = (
             "Error: AlignTestCasesSection: Failed to import. "


### PR DESCRIPTION
Add skips on settings (``[Arguments]``, ``[Setup]``...). 


Current syntax of the skip allow me to define it freely how I want - but I break DRY principle and I repeat a lot of the code in different places. I'm aware of it and I will refactor it (but it's not in the scope of this PR).