### PR TITLE
Improve compact_overflow mode for AlignTestCases/KeywordsSection transformers

### DIFF
--- a/docs/releasenotes/3.0b2.rst
+++ b/docs/releasenotes/3.0b2.rst
@@ -105,6 +105,7 @@ IndentNestedKeywords - AND handling
 
 ::
 
+<<<<<<< HEAD
     *** Keywords ***
         Keyword
             Run Keywords
@@ -130,6 +131,13 @@ Example output::
 By default too long lines are split to multiple lines, one value per line.
 You can change this behaviour to put multiple values in one line till the character limit
 with ``split_on_every_value`` flag (default ``False``).
+=======
+*** Keywords ***
+    Keyword
+        Run Keywords
+        ...    No Operation  arg    AND
+        ...    No Operation  arg1  arg2
+>>>>>>> b7e44f1... Fix RenameKeywords incorrectly renaming the keywords with dots/underscores followed by space
 
 Continuation indent
 --------------------

--- a/docs/releasenotes/3.0b2.rst
+++ b/docs/releasenotes/3.0b2.rst
@@ -105,7 +105,6 @@ IndentNestedKeywords - AND handling
 
 ::
 
-<<<<<<< HEAD
     *** Keywords ***
         Keyword
             Run Keywords
@@ -131,13 +130,6 @@ Example output::
 By default too long lines are split to multiple lines, one value per line.
 You can change this behaviour to put multiple values in one line till the character limit
 with ``split_on_every_value`` flag (default ``False``).
-=======
-*** Keywords ***
-    Keyword
-        Run Keywords
-        ...    No Operation  arg    AND
-        ...    No Operation  arg1  arg2
->>>>>>> b7e44f1... Fix RenameKeywords incorrectly renaming the keywords with dots/underscores followed by space
 
 Continuation indent
 --------------------

--- a/docs/source/transformers/AlignKeywordsSection.rst
+++ b/docs/source/transformers/AlignKeywordsSection.rst
@@ -147,6 +147,40 @@ See example (for ``fixed`` alignment type and default width ``24``):
             Multi                   ${arg}
             ...                     ${arg}
 
+Compact overflow
+-----------------
+Compact overflow tries to fit too long tokens between the alignment columns.
+This behaviour is controlled with ``compact_overflow_limit = 2`` parameter. If more than configured limit columns are
+misaligned in a row, the ``overflow`` mode is used instead of ``compact_overflow``.
+This behaviour helps in avoiding the situation, where ``compact_overflow`` misalign whole line if most of the tokens
+does not fit in the column.
+
+Below example was run with config::
+
+    robotidy -c AlignKeywordsSection:enabled=True:handle_too_long=compact_overflow:widths=24,28,20 src.robot
+
+.. tabs::
+
+    .. code-tab:: robotframework Before
+
+        *** Keywords ***
+        Keyword
+            # compact overflow will be used as we only "misalign" two columns in a row
+            LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO}    ${TILAUS}    ${OSTOTILAUS}    ${LÄHETYS}    ${TILAUSPVM}
+
+            # more than two columns are misaligned - using "overflow" instead
+            LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO_LONGER}    ${TILAUS_OCC}    ${OSTOTILAUS}    ${LÄHETYS}    ${TILAUSPVM}
+
+    .. code-tab:: robotframework After
+
+        *** Keywords ***
+        Keyword
+            # compact overflow will be used as we only "misalign" two columns in a row
+            LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO}    ${TILAUS}       ${OSTOTILAUS}       ${LÄHETYS}          ${TILAUSPVM}
+
+            # more than two columns are misaligned - using "overflow" instead
+            LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO_LONGER}             ${TILAUS_OCC}       ${OSTOTILAUS}       ${LÄHETYS}          ${TILAUSPVM}
+
 Alignment of the indented blocks
 --------------------------------
 Indented blocks (``FOR``, ``IF``, ``WHILE``, ``TRY..EXCEPT..``) are aligned independently.

--- a/docs/source/transformers/AlignTestCasesSection.rst
+++ b/docs/source/transformers/AlignTestCasesSection.rst
@@ -148,6 +148,39 @@ See example (for ``fixed`` alignment type and default width ``24``):
             Multi                   ${arg}
             ...                     ${arg}
 
+Compact overflow
+-----------------
+Compact overflow tries to fit too long tokens between the alignment columns.
+This behaviour is controlled with ``compact_overflow_limit = 2`` parameter. If more than configured limit columns are
+misaligned in a row, the ``overflow`` mode is used instead of ``compact_overflow``.
+This behaviour helps in avoiding the situation, where ``compact_overflow`` misalign whole line if most of the tokens
+does not fit in the column.
+
+Below example was run with config::
+
+    robotidy -c AlignKeywordsSection:enabled=True:handle_too_long=compact_overflow:widths=24,28,20 src.robot
+
+.. tabs::
+
+    .. code-tab:: robotframework Before
+
+        *** Test Cases ***
+        Test case
+            # compact overflow will be used as we only "misalign" two columns in a row
+            LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO}    ${TILAUS}    ${OSTOTILAUS}    ${LÄHETYS}    ${TILAUSPVM}
+
+            # more than two columns are misaligned - using "overflow" instead
+            LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO_LONGER}    ${TILAUS_OCC}    ${OSTOTILAUS}    ${LÄHETYS}    ${TILAUSPVM}
+
+    .. code-tab:: robotframework After
+
+        *** Test Cases ***
+        Test case
+            # compact overflow will be used as we only "misalign" two columns in a row
+            LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO}    ${TILAUS}       ${OSTOTILAUS}       ${LÄHETYS}          ${TILAUSPVM}
+
+            # more than two columns are misaligned - using "overflow" instead
+            LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO_LONGER}             ${TILAUS_OCC}       ${OSTOTILAUS}       ${LÄHETYS}          ${TILAUSPVM}
 
 Alignment of the indented blocks
 --------------------------------

--- a/robotidy/transformers/AlignKeywordsSection.py
+++ b/robotidy/transformers/AlignKeywordsSection.py
@@ -45,15 +45,11 @@ class AlignKeywordsSection(AlignKeywordsTestsSection):
         widths: str = "",
         alignment_type: str = "fixed",
         handle_too_long: str = "overflow",
+        compact_overflow_limit: int = 2,
         skip_documentation: str = "True",  # noqa - override skip_documentation from Skip
         skip: Skip = None,
     ):
-        super().__init__(
-            widths,
-            alignment_type,
-            handle_too_long,
-            skip,
-        )
+        super().__init__(widths, alignment_type, handle_too_long, compact_overflow_limit, skip)
 
     @skip_if_disabled
     def visit_Keyword(self, node):  # noqa

--- a/robotidy/transformers/AlignTestCasesSection.py
+++ b/robotidy/transformers/AlignTestCasesSection.py
@@ -46,10 +46,11 @@ class AlignTestCasesSection(AlignKeywordsTestsSection):
         widths: str = "",
         alignment_type: str = "fixed",
         handle_too_long: str = "overflow",
+        compact_overflow_limit: int = 2,
         skip_documentation: str = "True",  # noqa - override skip_documentation from Skip
         skip: Skip = None,
     ):
-        super().__init__(widths, alignment_type, handle_too_long, skip)
+        super().__init__(widths, alignment_type, handle_too_long, compact_overflow_limit, skip)
 
     def visit_File(self, node):  # noqa
         if is_suite_templated(node):

--- a/tests/atest/transformers/AlignKeywordsSection/expected/overflow_first_line.robot
+++ b/tests/atest/transformers/AlignKeywordsSection/expected/overflow_first_line.robot
@@ -8,7 +8,7 @@ compact_overflow issue case
     ...                     lähde=${LÄHDE}              hinta_yks=${HINTA_YKSI}    hinta_rivi=${HINTA_RIVI}
 
     RaAn_RaporttiTarkista_REP98
-    ...                     70 Procurement              RPOR LOG Ostoa odottavat rivit (REP98).xdo    HTML    ${LUONTIYKSIKKÖ}
+    ...                     70 Procurement              RPOR LOG Ostoa odottavat rivit (REP98).xdo    HTML          ${LUONTIYKSIKKÖ}
     ...                     ${LIIKEYKSIKKÖ}             ${TOIMITTAJA}       ${TOIMITTAJAN_TOIMIPAIKKA}    ${ASIAKASTYYPPI}    ${NIMIKETYYPPI}
 
 compact_overflow OK working case

--- a/tests/atest/transformers/AlignTestCasesSection/expected/compact_overflow_bug.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/expected/compact_overflow_bug.robot
@@ -3,4 +3,4 @@ Test
     VaHa_ValmiitTapahtumatTarkista_Osto    ${NIMIKE}    Ostotilaus          ${OSTOTILAUS}       ${MAARA}            ${ALIVARASTO}       varastopaika=${EMPTY}    tilauspvm=${TILAUSPVM}
 
 Test2
-    Lava_VastaanottotapahtumatTarkista    ${VASTAANOTTO}    ${TILAUS_OCC}    ${OSTOTILAUS}      ${LAHETYS}          ${TILAUSPVM}        ${NIMIKE}           ${NIMIKEKUVAUS}
+    Lava_VastaanottotapahtumatTarkista    ${VASTAANOTTO}                    ${TILAUS_OCC}       ${OSTOTILAUS}       ${LAHETYS}          ${TILAUSPVM}        ${NIMIKE}           ${NIMIKEKUVAUS}

--- a/tests/atest/transformers/AlignTestCasesSection/expected/dynamic_compact_overflow.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/expected/dynamic_compact_overflow.robot
@@ -1,0 +1,20 @@
+*** Test Cases ***
+Test compact overflow with compact overflow limit
+    # current compact overflow can go over multiple columns, better to be dynamic compact overflow, used ONLY if really makes it more compact from next column already (not ever two columns in a row misaligned from rest)
+
+    # use compact_overflow for TILAUS to "win" one column
+    LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO}    ${TILAUS}       ${OSTOTILAUS}       ${LÄHETYS}          ${TILAUSPVM}        ${NIMIKE}           ${NIMIKEKUVAUS}
+    LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO}    ${TILAUS}       ${OSTOTILAUS}       ${LÄHETYS}          ${TILAUSPVM}        ${NIMIKE}           ${NIMIKEKUVAUS}
+
+    # better to fallback to normal overflow in this case if compact overflow is not helping to align next column tighter
+    LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO_LONGER}             ${TILAUS_OCC}       ${OSTOTILAUS}       ${LÄHETYS}          ${TILAUSPVM}        ${NIMIKE}           ${NIMIKEKUVAUS}
+    LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO_LONGER}             ${TILAUS_OCC}       ${OSTOTILAUS}       ${LÄHETYS}          ${TILAUSPVM}        ${NIMIKE}           ${NIMIKEKUVAUS}
+
+    # more complex case with two times in same row, first expecting fallback, second normal compact
+    LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO_LONGER}             ${TILAUS_OCC}       ${OSTOTILAUS}       ${LÄHETYS_LONGERTXT}    ${TILAUSPVM}    ${NIMIKE}           ${NIMIKEKUVAUS}
+    LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO_LONGER}             ${TILAUS_OCC}       ${OSTOTILAUS}       ${LÄHETYS_LONGERTXT}    ${TILAUSPVM}    ${NIMIKE}           ${NIMIKEKUVAUS}
+
+    LäVa_VastaaShort        ${VASTAANOTTO_MUCHLONGERTX}    ${TILAUS_OCC}    ${OSTOTILAUS}
+    LäVa_VastaaShort        ${VASTAANOTTO_MUCHLONGERTX}    ${TILAUS_OCC}    ${OSTOTILAUS}
+    LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO_LONGER}             ${TILAUS_OCC}       ${OSTOTILAUS}
+    LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO_LONGER}             ${TILAUS_OCC}       ${OSTOTILAUS}

--- a/tests/atest/transformers/AlignTestCasesSection/expected/dynamic_compact_overflow_limit_1.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/expected/dynamic_compact_overflow_limit_1.robot
@@ -1,0 +1,11 @@
+*** Test Cases ***
+Test compact overflow with compact overflow limit = 1
+    ${PALAUTUKSENVASTAANOTTO}=                          VaHa_VastaanottoLuo_Palautustilaus      ${NIMIKE}           ${MÄÄRÄ}            ${PALAUTUSTILAUS}    ${ALIVARASTO}
+
+    ${PALAUTUKSENVASTAANOTTO}=                          VaHa_VastaanottoLuo_Palautustilaus      ${NIMIKE}           ${MÄÄRÄ}            ${PALAUTUSTILAUS}    ${ALIVARASTO}
+
+    # once critical issue - even if too long token barely fits in two columns,
+    # the next token should start with + 1 column because sep does not fit
+    ${OSTOTILAUS}           ${TOIMITUSPÄIVÄ}=           OsTi_OstotilausLuo_Hankintaehdotuksesta                     ${HANKINTAEHDOTUS}    ${TILAUSPVM}
+
+    ${OSTOTILAUS}           ${TOIMITUSPÄIVÄ}=           OsTi_OstotilausLuo_Hankintaehdotuksesta                     ${HANKINTAEHDOTUS}    ${TILAUSPVM}

--- a/tests/atest/transformers/AlignTestCasesSection/expected/overflow_first_line.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/expected/overflow_first_line.robot
@@ -8,7 +8,7 @@ compact_overflow issue case
     ...                     lähde=${LÄHDE}              hinta_yks=${HINTA_YKSI}    hinta_rivi=${HINTA_RIVI}
 
     RaAn_RaporttiTarkista_REP98
-    ...                     70 Procurement              RPOR LOG Ostoa odottavat rivit (REP98).xdo    HTML    ${LUONTIYKSIKKÖ}
+    ...                     70 Procurement              RPOR LOG Ostoa odottavat rivit (REP98).xdo    HTML          ${LUONTIYKSIKKÖ}
     ...                     ${LIIKEYKSIKKÖ}             ${TOIMITTAJA}       ${TOIMITTAJAN_TOIMIPAIKKA}    ${ASIAKASTYYPPI}    ${NIMIKETYYPPI}
 
 compact_overflow OK working case

--- a/tests/atest/transformers/AlignTestCasesSection/source/dynamic_compact_overflow.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/source/dynamic_compact_overflow.robot
@@ -1,0 +1,20 @@
+*** Test Cases ***
+Test compact overflow with compact overflow limit
+    # current compact overflow can go over multiple columns, better to be dynamic compact overflow, used ONLY if really makes it more compact from next column already (not ever two columns in a row misaligned from rest)
+
+    # use compact_overflow for TILAUS to "win" one column
+    LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO}    ${TILAUS}    ${OSTOTILAUS}    ${LÄHETYS}    ${TILAUSPVM}    ${NIMIKE}    ${NIMIKEKUVAUS}
+    LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO}    ${TILAUS}       ${OSTOTILAUS}       ${LÄHETYS}          ${TILAUSPVM}        ${NIMIKE}           ${NIMIKEKUVAUS}
+
+    # better to fallback to normal overflow in this case if compact overflow is not helping to align next column tighter
+    LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO_LONGER}    ${TILAUS_OCC}    ${OSTOTILAUS}    ${LÄHETYS}    ${TILAUSPVM}    ${NIMIKE}    ${NIMIKEKUVAUS}
+    LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO_LONGER}             ${TILAUS_OCC}       ${OSTOTILAUS}       ${LÄHETYS}          ${TILAUSPVM}        ${NIMIKE}           ${NIMIKEKUVAUS}
+
+    # more complex case with two times in same row, first expecting fallback, second normal compact
+    LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO_LONGER}    ${TILAUS_OCC}    ${OSTOTILAUS}    ${LÄHETYS_LONGERTXT}    ${TILAUSPVM}    ${NIMIKE}    ${NIMIKEKUVAUS}
+    LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO_LONGER}             ${TILAUS_OCC}       ${OSTOTILAUS}       ${LÄHETYS_LONGERTXT}    ${TILAUSPVM}    ${NIMIKE}           ${NIMIKEKUVAUS}
+
+    LäVa_VastaaShort    ${VASTAANOTTO_MUCHLONGERTX}    ${TILAUS_OCC}    ${OSTOTILAUS}
+    LäVa_VastaaShort        ${VASTAANOTTO_MUCHLONGERTX}    ${TILAUS_OCC}    ${OSTOTILAUS}
+    LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO_LONGER}    ${TILAUS_OCC}    ${OSTOTILAUS}
+    LäVa_VastaanottotapahtumatTarkista    ${VASTAANOTTO_LONGER}             ${TILAUS_OCC}       ${OSTOTILAUS}

--- a/tests/atest/transformers/AlignTestCasesSection/source/dynamic_compact_overflow_limit_1.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/source/dynamic_compact_overflow_limit_1.robot
@@ -1,0 +1,11 @@
+*** Test Cases ***
+Test compact overflow with compact overflow limit = 1
+    ${PALAUTUKSENVASTAANOTTO}=                          VaHa_VastaanottoLuo_Palautustilaus    ${NIMIKE}    ${MÄÄRÄ}    ${PALAUTUSTILAUS}    ${ALIVARASTO}
+
+    ${PALAUTUKSENVASTAANOTTO}=                          VaHa_VastaanottoLuo_Palautustilaus      ${NIMIKE}           ${MÄÄRÄ}    ${PALAUTUSTILAUS}           ${ALIVARASTO}
+
+    # once critical issue - even if too long token barely fits in two columns,
+    # the next token should start with + 1 column because sep does not fit
+    ${OSTOTILAUS}           ${TOIMITUSPÄIVÄ}=           OsTi_OstotilausLuo_Hankintaehdotuksesta   ${HANKINTAEHDOTUS}    ${TILAUSPVM}
+
+    ${OSTOTILAUS}           ${TOIMITUSPÄIVÄ}=           OsTi_OstotilausLuo_Hankintaehdotuksesta                     ${HANKINTAEHDOTUS}    ${TILAUSPVM}

--- a/tests/atest/transformers/AlignTestCasesSection/test_transformer.py
+++ b/tests/atest/transformers/AlignTestCasesSection/test_transformer.py
@@ -91,3 +91,15 @@ class TestAlignTestCasesSection(TransformerAcceptanceTest):
 
     def test_compact_overflow_bug(self):
         self.compare(source="compact_overflow_bug.robot", config=":widths=24,28,20:handle_too_long=compact_overflow")
+
+    def test_dynamic_compact_overflow(self):
+        self.compare(
+            source="dynamic_compact_overflow.robot",
+            config=":widths=24,28,20:handle_too_long=compact_overflow:skip_keyword_call=Log",
+        )
+
+    def test_dynamic_compact_overflow_limit_1(self):
+        self.compare(
+            source="dynamic_compact_overflow_limit_1.robot",
+            config=":widths=24,28,20:handle_too_long=compact_overflow:skip_keyword_call=Log:compact_overflow_limit=1",
+        )

--- a/tests/utest/test_cli.py
+++ b/tests/utest/test_cli.py
@@ -86,6 +86,7 @@ class TestCli:
             "widths",
             "alignment_type",
             "handle_too_long",
+            "compact_overflow_limit",
             "skip_documentation",
         ]
         # skip_documentation is overridden in transformer - the order is different because of that


### PR DESCRIPTION
Previously aligners with handle_too_long=compact_overflow mode didn't have any limit on misaligned columns. That means if there was situation where too long token could not be "compensated" by breaking alignment of several columns the whole line would be misaligned. Now there is default limit (``compact_overflow_limit = 2``) which will fallback to normal overflow mode if the compact mode breaks the alignment with too many columns in a row.

It's one of the smaller edge cases but we need this update to have truly perfect aligners :) 