### PR TITLE
(Truly) skip formatting return values

### DIFF
--- a/robotidy/transformers/aligners_core.py
+++ b/robotidy/transformers/aligners_core.py
@@ -321,7 +321,7 @@ class AlignKeywordsTestsSection(Transformer):
         tokens, comments = separate_comments(line)
         if len(tokens) < 2:  # only happens with weird encoding, better to skip
             return None
-        aligned = self.align_tokens(tokens[:-2], indent)
+        aligned = self.align_tokens(tokens[:-2], indent, self.handle_too_long)
         last_token = strip_extra_whitespace(tokens[-2])
         aligned.extend([last_token, *join_comments(comments), tokens[-1]])
         return aligned

--- a/tests/atest/transformers/AlignKeywordsSection/expected/one_column.robot
+++ b/tests/atest/transformers/AlignKeywordsSection/expected/one_column.robot
@@ -20,6 +20,7 @@ Misaligned
 Misaligned with empty
     Keyword
     ...                     misaligned
+
     ...                     arg
 
 Edge Cases

--- a/tests/atest/transformers/AlignKeywordsSection/expected/skip_keywords.robot
+++ b/tests/atest/transformers/AlignKeywordsSection/expected/skip_keywords.robot
@@ -12,11 +12,11 @@ Exclude whole multiline case by rule "Should_Not_Be_None"
 
     not_prefix_starts_with                          ${ARG}
 
-    ${HINTA_YKSI}    ${HINTA_RIVI}    ${HINTA_TILAUS_ALV}    ${toimituspvm}=
+    ${HINTA_YKSI}  ${HINTA_RIVI}  ${HINTA_TILAUS_ALV}  ${toimituspvm}=
     ...                     TiHa_MyyntitilausTarkista_Tiedot
     ...                     ${TILAUS_FUSION}        ${NIMIKE}               ${NIMIKEKUVAUS}         ${MÄÄRÄ}                ${MITTAYKSIKKÖ}         ${TILAUSPVM}
     ...                     ${ASIAKAS}              ${ASIAKAS_ID}           ${LÄHETYSOSOITE}        ${LÄHETYSTAPA}          ${LASKUTUSOSOITE}
     ...                     ${LIIKEYKSIKKÖ}         ${TILAAJA}              tila_tilaus=Käsittelyssä                        tila_tilausrivi=Odottaa lähetystä
     ...                     lähde=${LÄHDE}          hinta_yks=${HINTA_YKSI}                         hinta_rivi=${HINTA_RIVI}
 
-    ${HINTA_YKSI}    ${HINTA_RIVI}    ${HINTA_TILAUS_ALV}    ${toimituspvm}    TiHa_MyyntitilausTarkista_Tiedot
+    ${HINTA_YKSI}  ${HINTA_RIVI}  ${HINTA_TILAUS_ALV}  ${toimituspvm}       TiHa_MyyntitilausTarkista_Tiedot

--- a/tests/atest/transformers/AlignKeywordsSection/expected/skip_return_values.robot
+++ b/tests/atest/transformers/AlignKeywordsSection/expected/skip_return_values.robot
@@ -1,0 +1,16 @@
+*** Keywords ***
+Skip return values
+    # single return value case
+    ${def_xhrtimeout}=      SetConfig                   XHRTimeout          0s
+    ${def_xhrtimeout}=      SetConfig                   XHRTimeout          0s
+    ${def_xhrtimeout}=      SetConfig                   XHRTimeout          0s
+
+    ${a}    ${b}=           SomeKeyword                 somevalue
+    ${a}    ${b}=           SomeKeyword                 somevalue
+
+    # alignment between return values is left completely as is
+    ${TILAUS_OCC}   ${HINTA_YKSI}   ${HINTA_RIVI}   ${HINTA_TILAUS}   ${TILAUSPVM}=             OCC_TilausTee_fi
+    ${TILAUS_OCC}    ${HINTA_YKSI}    ${HINTA_RIVI}    ${HINTA_TILAUS}    ${TILAUSPVM}=         OCC_TilausTee_fi
+
+    ${single}
+    ...                     Keyword                     Call

--- a/tests/atest/transformers/AlignKeywordsSection/source/skip_return_values.robot
+++ b/tests/atest/transformers/AlignKeywordsSection/source/skip_return_values.robot
@@ -1,0 +1,16 @@
+*** Keywords ***
+Skip return values
+    # single return value case
+    ${def_xhrtimeout}=          SetConfig  XHRTimeout  0s
+    ${def_xhrtimeout}=      SetConfig                   XHRTimeout          0s
+    ${def_xhrtimeout}=    SetConfig                 XHRTimeout                  0s
+
+    ${a}    ${b}=           SomeKeyword                 somevalue
+    ${a}    ${b}=    SomeKeyword                    somevalue
+
+    # alignment between return values is left completely as is
+    ${TILAUS_OCC}   ${HINTA_YKSI}   ${HINTA_RIVI}   ${HINTA_TILAUS}   ${TILAUSPVM}=             OCC_TilausTee_fi
+    ${TILAUS_OCC}    ${HINTA_YKSI}    ${HINTA_RIVI}    ${HINTA_TILAUS}    ${TILAUSPVM}=    OCC_TilausTee_fi
+
+    ${single}
+    ...    Keyword    Call

--- a/tests/atest/transformers/AlignKeywordsSection/test_transformer.py
+++ b/tests/atest/transformers/AlignKeywordsSection/test_transformer.py
@@ -94,3 +94,9 @@ class TestAlignKeywordsSection(TransformerAcceptanceTest):
 
     def test_error_node(self):
         self.compare(source="error_node.robot", not_modified=True, target_version=5)
+
+    def test_skip_return_values(self):
+        self.compare(
+            source="skip_return_values.robot",
+            config=":widths=24,28,20:handle_too_long=compact_overflow:skip_return_values=True",
+        )

--- a/tests/atest/transformers/AlignTestCasesSection/expected/one_column.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/expected/one_column.robot
@@ -20,6 +20,7 @@ Misaligned
 Misaligned with empty
     Keyword
     ...                     misaligned
+
     ...                     arg
 
 Edge Cases

--- a/tests/atest/transformers/AlignTestCasesSection/expected/skip_keywords.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/expected/skip_keywords.robot
@@ -12,15 +12,15 @@ Exclude whole multiline case by rule "Should_Not_Be_None"
 
     not_prefix_starts_with                          ${ARG}
 
-    ${HINTA_YKSI}    ${HINTA_RIVI}    ${HINTA_TILAUS_ALV}    ${toimituspvm}=
+    ${HINTA_YKSI}  ${HINTA_RIVI}  ${HINTA_TILAUS_ALV}  ${toimituspvm}=
     ...                     TiHa_MyyntitilausTarkista_Tiedot
     ...                     ${TILAUS_FUSION}        ${NIMIKE}               ${NIMIKEKUVAUS}             ${MÄÄRÄ}                    ${MITTAYKSIKKÖ}             ${TILAUSPVM}
     ...                     ${ASIAKAS}              ${ASIAKAS_ID}           ${LÄHETYSOSOITE}            ${LÄHETYSTAPA}              ${LASKUTUSOSOITE}
     ...                     ${LIIKEYKSIKKÖ}         ${TILAAJA}              tila_tilaus=Käsittelyssä    tila_tilausrivi=Odottaa lähetystä
     ...                     lähde=${LÄHDE}          hinta_yks=${HINTA_YKSI}                             hinta_rivi=${HINTA_RIVI}
 
-    ${HINTA_YKSI}    ${HINTA_RIVI}    ${HINTA_TILAUS_ALV}    ${toimituspvm}    TiHa_MyyntitilausTarkista_Tiedot
+    ${HINTA_YKSI}  ${HINTA_RIVI}  ${HINTA_TILAUS_ALV}  ${toimituspvm}       TiHa_MyyntitilausTarkista_Tiedot
 
-    ${one_assign}    Keyword                        ${multiple}             ${arguments}                ${should_be}                ${aligned}
+    ${one_assign}           Keyword                 ${multiple}             ${arguments}                ${should_be}                ${aligned}
 
-    ${assign}    ${two_assign_vars}    Keyword      ${multiple}             ${arguments}                ${should_be}                ${aligned}
+    ${assign}    ${two_assign_vars}                 Keyword                 ${multiple}                 ${arguments}                ${should_be}                ${aligned}


### PR DESCRIPTION
skip return values option (for aligners) did not truly skip formatting them - it just used fixed separator. This PR improves it and skips the formatting of the return values.

Since our align implementation discarded all whitespace tokens before I had to update it a bit to discard them only after we capture return values (in case we want to skip formatting).