### PR TITLE
Add End To End tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -45,7 +45,7 @@ jobs:
         pip install .[dev]
     - name: Run unit tests with coverage
       run:
-        coverage run -m pytest
+        coverage run -m pytest --e2e
     - name: Codecov
       uses: codecov/codecov-action@v1.0.11
       with:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+From Robotidy 3.0 see release notes in ``docs/releasenote`` directory.
 
 ### Other
 - Robotidy transformers now inherits from ``Transformer`` core class (instead of ``ModelTransformer``). 

--- a/docs/releasenotes/3.1.rst
+++ b/docs/releasenotes/3.1.rst
@@ -1,0 +1,12 @@
+Robotidy 3.1
+=========================================
+
+Fixes
+------
+- Improved stability of the Robotidy output. Now it should provide the code that does not
+  change after several reruns (`#360 <https://github.com/MarketSquare/robotframework-tidy/issues/360>`_)
+
+Other
+------
+- Added end to end tests to Robotidy. It should help with improving stability of the tool and catch some of the
+  bugs earlier (previously transformers were tested mostly in the isolation) (`#361 <https://github.com/MarketSquare/robotframework-tidy/issues/361>`_)

--- a/robotidy/transformers/SplitTooLongLine.py
+++ b/robotidy/transformers/SplitTooLongLine.py
@@ -99,9 +99,15 @@ class SplitTooLongLine(Transformer):
     def should_transform_node(self, node):
         if all(line[-1].end_col_offset < self.line_length for line in node.lines):
             return False
-        if not len(node.data_tokens) > 1:  # nothing to split anyway
-            return False
-        return True
+        # find if any line contains more than one data tokens - so we have something to split
+        for line in node.lines:
+            count = 0
+            for token in line:
+                if token.type not in Token.NON_DATA_TOKENS:
+                    count += 1
+                if count > 1:
+                    return True
+        return False
 
     def visit_KeywordCall(self, node):  # noqa
         if not self.should_transform_node(node):

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -66,3 +66,26 @@ But in first case our output will be compared to ``option1.robot`` file and in s
 
 For negative test scenarios you can use ``run_tidy`` method (also used by ``compare`` under hood) with
 optional expected ``exit_code`` argument.
+
+End to end tests
+-----------------
+E2E tests focus on verifying the stability of the Robotidy output. It includes:
+
+  - ensuring that code will not be modified after several reruns of the tool
+  - AST model modified by one transformer can be safely parsed by another transformer
+
+E2E tests are defined in ``tests/e2e`` directory. They are skipped by default - since they take
+longer time to finish. To enable them add ``--e2e`` flag to pytest command.
+
+Due to the amount of the work needed to also define end to end tests our tests reuse the same
+sources as acceptance tests. You can define additional tests by creating robot files that will be
+transformed in the ``tests/e2e/test_data`` directory.
+
+Every test data file is used to generate two tests:
+
+  - transform with all default transformers (excluding disabled by default)
+  - transform with all transformers (including disabled by default)
+
+If the test data file is invalid (and cannot be used in E2E tests) you can add it to ``SKIP_TESTS`` dictionary.
+Otherwise if the test data require more than default 1 rerun of the tool you can set amount of reruns needed in
+``RERUN_NEEDED`` dictionary.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--e2e", action="store_true", default=False, help="Run end to end tests")
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "e2e: mark tests as end to end tests")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--e2e"):
+        return
+    skip_e2e = pytest.mark.skip(reason="Need --e2e option to run")
+    for item in items:
+        if "e2e" in item.keywords:
+            item.add_marker(skip_e2e)

--- a/tests/e2e/test_data/too_long_variable.robot
+++ b/tests/e2e/test_data/too_long_variable.robot
@@ -1,0 +1,5 @@
+*** Variables ***
+&{sync modules}
+...    over_the_top_of_reasonable_super_duper_really_Over_the_top_Really_Extra_ordinarily_long_key_1=value1
+${thing2}
+...    over_the_top_of_reasonable_super_duper_really_Over_the_top_Really_Extra_ordinarily_long_string_no_I_mean_really_really_long

--- a/tests/e2e/test_transform_stability.py
+++ b/tests/e2e/test_transform_stability.py
@@ -1,0 +1,167 @@
+import functools
+import shutil
+from pathlib import Path
+from typing import List, Tuple
+
+import pytest
+from click.testing import CliRunner
+
+from robotidy.cli import cli
+from robotidy.transformers import load_transformers
+from robotidy.utils import ROBOT_VERSION
+
+RERUN_NEEDED = {
+    "AddMissingEnd": {"test": 2},
+    "AlignKeywordsSection": {
+        "blocks_rf5": 2,
+        "non_ascii_spaces": 2,
+    },
+    "AlignSettingsSection": {"blank_line_doc": 2},
+    "AlignTemplatedTestCases": {"with_settings": 2},
+    "AlignTestCasesSection": {
+        "blocks_rf5": 2,
+        "compact_overflow_bug": 2,
+        "dynamic_compact_overflow": 2,
+        "dynamic_compact_overflow_limit_1": 2,
+        "non_ascii_spaces": 2,
+        "skip_keywords": 2,
+        "overflow_first_line": 2,
+    },
+    "IndentNestedKeywords": {"run_keyword": 2},
+    "InlineIf": {
+        "invalid_if": 2,
+        "invalid_inline_if": 3,
+        "test": 2,
+        "test_disablers": 2,
+    },
+    "MergeAndOrderSections": {"parsing_error": 2},
+    "NormalizeNewLines": {"tests": 2},
+    "NormalizeSeparators": {"disablers": 2, "pipes": 2},
+    "NormalizeSettingName": {"disablers": 2},
+    "NormalizeTags": {"disablers": 2},
+    "OrderSettings": {"test": 2},
+    "RemoveEmptySettings": {"empty": 2, "disablers": 2, "overwritten": 2},
+    "RenameKeywords": {"disablers": 2},
+    "ReplaceBreakContinue": {"test": 2},
+    "ReplaceReturns": {"replace_returns_disablers": 2, "return_from_keyword": 2, "test": 2},
+    "ReplaceRunKeywordIf": {"configure_whitespace": 2, "disablers": 3, "set_variable_workaround": 2, "tests": 2},
+    "SmartSortKeywords": {"multiple_sections": 2, "sort_input": 2},
+    "SplitTooLongLine": {"continuation_indent": 2, "disablers": 2, "tests": 2},
+}
+SKIP_TESTS = {"ReplaceRunKeywordIf": {"invalid_data"}, "SplitTooLongLine": {"variables"}}
+
+
+def run_tidy(cmd, enable_disabled: bool):
+    if enable_disabled:
+        cmd = get_enable_disabled_config() + cmd
+    runner = CliRunner()
+    return runner.invoke(cli, cmd)
+
+
+def run_with_source(source: Path, enable_disabled: bool):
+    cmd = [str(source)]
+    result = run_tidy(cmd, enable_disabled)
+    if result.exit_code != 0:
+        raise AssertionError(f"Run failed for {source}")
+
+
+def run_with_source_and_check(source: Path, orig: Path, enable_disabled: bool):
+    cmd = ["--diff", "--check", "--overwrite", str(source)]
+    result = run_tidy(cmd, enable_disabled)
+    if result.exit_code != 0:
+        print(result.output)
+        raise AssertionError(f"The code was modified for {orig}")
+
+
+@functools.lru_cache(1)
+def get_enable_disabled_config() -> List[str]:
+    """Returns config required to enable all disabled transformers."""
+
+    def is_transformer_disabled(transformer):
+        return not getattr(transformer, "ENABLED", True)
+
+    transformers = load_transformers(None, {}, allow_disabled=True, target_version=ROBOT_VERSION.major)
+    config = []
+    for transformer in transformers:
+        if not is_transformer_disabled(transformer):
+            continue
+        name = transformer.__class__.__name__
+        config.extend(["--configure", f"{name}:enabled=True"])
+    return config
+
+
+def is_e2e_only(path: Path) -> bool:
+    return path.parent.parent.name == "e2e"
+
+
+def get_test_attributes_from_path(path: Path) -> Tuple[str, str]:
+    transformer = path.parent.parent.name
+    test_name = path.stem
+    return transformer, test_name
+
+
+def should_be_skip(path: Path) -> bool:
+    """
+    Checks if test file is in list of invalid data that cannot pass stability checks.
+    """
+    if is_e2e_only(path):
+        return False
+    transformer, test_name = get_test_attributes_from_path(path)
+    if transformer not in SKIP_TESTS:
+        return False
+    return test_name in SKIP_TESTS[transformer]
+
+
+def reruns_needed(path: Path) -> int:
+    """
+    Check if test data requires extra rerun.
+    An example would be for example missing END, which is added in the first run,
+    newly created blocks fixed in the second and third run should not modify code.
+    Returns number of reruns needed.
+    """
+    if is_e2e_only(path):
+        return 1
+    transformer, test_name = get_test_attributes_from_path(path)
+    if transformer not in RERUN_NEEDED:
+        return 1
+    return RERUN_NEEDED[transformer].get(test_name, 1)
+
+
+def gen_test_data():
+    """
+    Yields list of test data paths. Paths are:
+      - *.robot files inside e2e/test_data directory
+      - *.robot files inside atest/*/source directories
+    """
+    e2e_dir = Path(__file__).parent
+    atest_dir = e2e_dir.parent / "atest" / "transformers"
+
+    yield from e2e_dir.rglob("test_data/*.robot")
+    for path in atest_dir.rglob("*/source/*.robot"):
+        yield path
+
+
+def get_test_id_from_path(path) -> str:
+    """Generate test id from path to the source file."""
+    test_name = path.stem
+    if path.parent.parent.name == "e2e":
+        return f"e2e_{test_name}"
+    transformer = path.parent.parent.name
+    return f"{transformer}_{test_name}"
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("test_file", gen_test_data(), ids=get_test_id_from_path)
+@pytest.mark.parametrize("enable_disabled", [False, True], ids=["defaults", "all"])
+def test_stability_of_transformation(tmpdir, test_file, enable_disabled):
+    if should_be_skip(test_file):
+        pytest.skip("Skip invalid test data")
+    reruns = reruns_needed(test_file)
+    # copy test data to temp directory
+    test_data_dst = tmpdir / test_file.name
+    shutil.copy(test_file, test_data_dst)
+    for _ in range(reruns):
+        run_with_source(test_data_dst, enable_disabled)
+    for _ in range(2):
+        # rerun with --check twice to confirm stability
+        run_with_source_and_check(test_data_dst, test_file, enable_disabled)

--- a/tests/e2e/test_transform_stability.py
+++ b/tests/e2e/test_transform_stability.py
@@ -12,10 +12,7 @@ from robotidy.utils import ROBOT_VERSION
 
 RERUN_NEEDED = {
     "AddMissingEnd": {"test": 2},
-    "AlignKeywordsSection": {
-        "blocks_rf5": 2,
-        "non_ascii_spaces": 2,
-    },
+    "AlignKeywordsSection": {"blocks_rf5": 2, "non_ascii_spaces": 2},
     "AlignSettingsSection": {"blank_line_doc": 2},
     "AlignTemplatedTestCases": {"with_settings": 2},
     "AlignTestCasesSection": {


### PR DESCRIPTION
Added end to end tests to check if the Robotidy provided stable output with multiple reruns with all transformers on the code (and if output of one transformer does not break other transformers).

Also updated SplitTooLongLine transformer line length check to use "true" line length (calculated from token values) rather than ``end_col_offset`` which was not dynamic. The ``end_col_offset`` was calculated only once when loading the file from the disk and did not change after transformer modified the nodes - which lead to some stability issues.