### PR TITLE
Skip formatting of keyword calls in ``SplitTooLongLine`` transformer

### DIFF
--- a/docs/releasenotes/3.1.rst
+++ b/docs/releasenotes/3.1.rst
@@ -1,12 +1,21 @@
 Robotidy 3.1
 =========================================
 
-Fixes
-------
-- Improved stability of the Robotidy output. Now it should provide the code that does not
-  change after several reruns (`#360 <https://github.com/MarketSquare/robotframework-tidy/issues/360>`_)
+Tool consistency fixes
+---------------------
+Improved stability of the Robotidy output. Now it should provide the code that does not
+change after several reruns (`#360 <https://github.com/MarketSquare/robotframework-tidy/issues/360>`_)
 
-Other
-------
-- Added end to end tests to Robotidy. It should help with improving stability of the tool and catch some of the
+Skip handling
+--------------
+Added skip handling to ``SplitTooLongLine`` transformer. Now it is possible to skip keyword calls by name or pattern.
+For example, with following configuration::
+
+    robotidy -c SplitTooLongLine:skip_keyword_call=Catenate src
+
+All instances of the "Catenate" keyword call will not be formatted by ``SplitTooLongLine``.
+
+End to end tests
+-------------------
+Added end to end tests to Robotidy. It should help with improving stability of the tool and catch some of the
   bugs earlier (previously transformers were tested mostly in the isolation) (`#361 <https://github.com/MarketSquare/robotframework-tidy/issues/361>`_)

--- a/docs/source/configuration/skip_formatting.rst
+++ b/docs/source/configuration/skip_formatting.rst
@@ -10,6 +10,7 @@ Following transformers provide support for skip option:
 - :ref:`AlignKeywordsSection`
 - :ref:`AlignTestCasesSection`
 - :ref:`NormalizeSeparators`
+- :ref:`SplitTooLongLine`
 
 To see what types are possible to skip, see ``Skip formatting`` sections in each transformer documentation.
 

--- a/docs/source/transformers/SplitTooLongLine.rst
+++ b/docs/source/transformers/SplitTooLongLine.rst
@@ -124,4 +124,12 @@ Assignments will be split to multi lines if they don't fit together with Keyword
             ...    ${arg1}
             ...    ${arg2}
 
-Supports global formatting params: ``spacecount``, ``--startline`` and ``--endline``.
+Skip formatting
+----------------
+It is possible to use the following arguments to skip formatting of the code:
+
+- :ref:`skip keyword call`
+- :ref:`skip keyword call pattern`
+
+It is also possible to use disablers (:ref:`disablers`) but ``skip`` option
+makes it easier to skip all instances of given type of the code.

--- a/tests/atest/transformers/SplitTooLongLine/expected/skip_keywords.robot
+++ b/tests/atest/transformers/SplitTooLongLine/expected/skip_keywords.robot
@@ -1,0 +1,139 @@
+# Use 4 spaces separator and line_length=80
+
+*** Tasks ***
+
+Different keyword calls
+    This is a keyword     fits even with its    # comment
+
+    This is a keyword     fits with its               # comment, but has bad spacing
+
+    This is a keyword       these fit   but        only if you space them correctly
+
+    This is a keyword     these args do not fit       even if you set spacing properly
+
+    This is a keyword     this    last    argument    is    not    really    a # comment
+
+    This is a keyword     these    arguments    won't    fit    with     that   # comment
+
+    This is a keyword     these    arguments    won't    fit    with    or    without    that   # comment
+
+    This is a keyword     these     args    have    an    interesting
+    ...  # Edge case here →→→→→→→→→→→→→→→→                                    HERE
+    ...  More arguments here
+
+    This is a keyword     and     these      are       its     args
+    ...    here   are   some    more    args      to      split
+    ...    with                irregular                       spacing
+
+    ${assignment}=    This keyword sets the variable   using   these     args
+
+    ${assignment}=    This keyword sets the variable   using   these     args
+    ...    here   are   some    more    args      to      split
+    ...    with                irregular                       spacing
+
+
+    This is a keyword     and     these      are       its     args  # Comment
+
+    This is a keyword     and     these      are       its     arg   # Comment
+    ...    here   are   some    more    args
+    ...    with                irregular                       spacing
+
+    This is a keyword     and     these      are       its     arg   # Comment 1
+    ...    here   are   some    more    args                         # Comment 2
+    ...    with                irregular                     spacing # Not really a comment
+
+
+    ${assignment}=    This keyword sets the variable   using   these  args  # Comment
+
+    ${assignment}=    This keyword sets the variable   using   these     args
+    ...    here   are   some    more    args      to      split            # Comment
+    ...    with                irregular                       spacing
+
+
+Newlines
+    Keyword
+
+    # Newlines with trailing space are not changed
+        
+        
+
+    Keyword
+
+
+For loop
+    FOR   ${i}   IN    1  2  3  4  5  6  7  8  9  10  11  12  13  14  15  16  17  18  20
+        This is a keyword     fits even with its    # comment
+
+        This is a keyword     fits with its               # comment, but has bad spacing
+
+        This is a keyword     these fit         but only if you space them correctly
+
+        This is a keyword     these args do not fit       even if you set spacing properly
+
+        This is a keyword     this    last    argument    is    not    really    a # comment
+
+        This is a keyword     these    arguments    won't    fit    with     that   # comment
+
+        This is a keyword     these    arguments    won't    fit    with    or    without    that   # comment
+
+        This is a keyword     these     args    have    an    interesting
+        ...  # Edge case here →→→→→→→→→→→→→→→→                                    HERE
+        ...  More arguments here
+
+        This is a keyword     and     these      are       its     args
+        ...    here   are   some    more    args      to      split
+        ...    with                irregular                       spacing
+
+        ${assignment}=   This keyword sets the variable   using   these     args
+
+        ${assignment}=   This keyword sets the variable   using   these     args
+        ...    here   are   some    more    args      to      split
+        ...    with                irregular                       spacing
+
+
+        This is a keyword     and     these      are       its     args  # Comment
+
+        This is a keyword     and     these      are       its     arg   # Comment
+        ...    here   are   some    more    args
+        ...    with                irregular                       spacing
+
+        This is a keyword     and     these      are       its     arg   # Comment 1
+        ...    here   are   some    more    args                         # Comment 2
+        ...    with                irregular                     spacing # Not really a comment
+
+
+        ${assignment}=    This keyword sets the variable   using   these  args  # Comment
+
+        ${assignment}=    This keyword sets the variable   using   these     args
+        ...    here   are   some    more    args      to      split            # Comment
+        ...    with                irregular                       spacing
+    END
+
+
+If - else if - else clause
+    IF    ${some variable with a very long name} == ${some other variable with a long name}
+        ${assignment}=    This keyword sets the variable   using   these     args
+        ...    here   are   some    more    args      to      split            # Comment
+        ...    with                irregular                       spacing
+    ELSE IF    ${random} > ${NUMBER_TO_PASS_ON}
+        ${assignment}=    This keyword sets the variable   using   these     args
+        ...    here   are   some    more    args      to      split            # Comment
+        ...    with                irregular                       spacing
+    ELSE
+        ${assignment}=    This keyword sets the variable   using   these     args
+        ...    here   are   some    more    args      to      split            # Comment
+        ...    with                irregular                       spacing
+    END
+
+Too long inline IF  # shall be handled by InlineIf transformer
+    ${var}    ${var2}    IF    $condition != $condition2    Longer Keyword Name    ${argument}    values    ELSE IF    $condition2    Short Keyword    ${arg}  # comment
+
+Keyword name over the limit
+    Enter "${VNFname}" in the field with XPath "//label[contains(text(), 'Product Name')]/../mat-form-field/div/div/div/textarea"
+
+    ${assign}
+    ...    Enter "${VNFname}" in the field with XPath "//label[contains(text(), 'Product Name')]/../mat-form-field/div/div/div/textarea"
+
+    ${assign}
+    ...    ${assign}
+    ...    Enter "${VNFname}" in the field with XPath "//label[contains(text(), 'Product Name')]/../mat-form-field/div/div/div/textarea"

--- a/tests/atest/transformers/SplitTooLongLine/test_transformer.py
+++ b/tests/atest/transformers/SplitTooLongLine/test_transformer.py
@@ -80,3 +80,11 @@ class TestSplitTooLongLine(TransformerAcceptanceTest):
             expected="variables_feed.robot",
             config=":line_length=80:split_on_every_value=False",
         )
+
+    def test_skip_keywords(self):
+        self.compare(
+            source="tests.robot",
+            expected="skip_keywords.robot",
+            config=":line_length=80:skip_keyword_call=thisisakeyword:skip_keyword_call_pattern=(i?)sets\sthe\svariable",
+            target_version=5,
+        )


### PR DESCRIPTION
Now it is possible to skip formatting also with SplitTooLongLine transformer (for example for keywords with given name, that we don't want to split).