### PR TITLE
Fix skip_return_values using too low separator width for overflow column

### DIFF
--- a/robotidy/transformers/aligners_core.py
+++ b/robotidy/transformers/aligners_core.py
@@ -378,15 +378,24 @@ class AlignKeywordsTestsSection(Transformer):
             column += 1
         return column, abs(skip_width)
 
-    def align_tokens(self, tokens: List, skip_width: int):
-        prev_overflow_len, misaligned_cols = 0, 0
-        min_separator = self.formatting_config.space_count
-        aligned = []
+    def get_start_column_and_aligned(self, skip_width: int, min_separator: int):
+        """
+        In case we are skipping return tokens alignment, calculate starting column and create leading separator.
+        """
         if skip_width == 0:
-            column = 0
+            return 0, 0, []
+        column, skip_width = self.find_starting_column(skip_width)
+        if skip_width < min_separator:
+            prev_overflow_len = min_separator - skip_width
+            skip_width = min_separator
         else:
-            column, skip_width = self.find_starting_column(skip_width)
-            aligned.append(get_separator(skip_width))
+            prev_overflow_len = 0
+        return column, prev_overflow_len, [get_separator(skip_width)]
+
+    def align_tokens(self, tokens: List, skip_width: int):
+        last_assign, misaligned_cols = 0, 0
+        min_separator = self.formatting_config.space_count
+        column, prev_overflow_len, aligned = self.get_start_column_and_aligned(skip_width, min_separator)
         for index, token in enumerate(tokens):
             aligned.append(token)
             width = self.get_width(column)

--- a/tests/atest/transformers/AlignTestCasesSection/expected/skip_return_values_overflow.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/expected/skip_return_values_overflow.robot
@@ -1,0 +1,11 @@
+*** Test Cases ***
+Skip return values test
+    # bug when return value is exactly as long as the column:
+    ${additional_tab_value}=    Create List             Tuotekuvaus         Implantoitava tuote
+
+    # similar bug with -1 width:
+    ${additional_tab_valu}=    Create List              Tuotekuvaus         Implantoitava tuote
+
+    IF  '${varastosaldo}' != '0' or '${toimitusmäärä}' != '0' or '${kysynnänmäärä}' != '0'
+        ${TILAUS_OSTO_AVOIN}    ${HANKINTAEHDOTUS_AVOIN}    ${DUMMY}            ${TILAUS_AVOIN_OCC}=    RaAn_Raportti_AvoinTilausTarkista    ${NIMIKE}
+    END

--- a/tests/atest/transformers/AlignTestCasesSection/source/skip_return_values_overflow.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/source/skip_return_values_overflow.robot
@@ -1,0 +1,11 @@
+*** Test Cases ***
+Skip return values test
+    # bug when return value is exactly as long as the column:
+    ${additional_tab_value}=  Create List             Tuotekuvaus             Implantoitava tuote
+
+    # similar bug with -1 width:
+    ${additional_tab_valu}=    Create List              Tuotekuvaus         Implantoitava tuote
+
+    IF  '${varastosaldo}' != '0' or '${toimitusmäärä}' != '0' or '${kysynnänmäärä}' != '0'
+        ${TILAUS_OSTO_AVOIN}    ${HANKINTAEHDOTUS_AVOIN}    ${DUMMY}            ${TILAUS_AVOIN_OCC}=  RaAn_Raportti_AvoinTilausTarkista    ${NIMIKE}
+    END

--- a/tests/atest/transformers/AlignTestCasesSection/test_transformer.py
+++ b/tests/atest/transformers/AlignTestCasesSection/test_transformer.py
@@ -103,3 +103,13 @@ class TestAlignTestCasesSection(TransformerAcceptanceTest):
             source="dynamic_compact_overflow_limit_1.robot",
             config=":widths=24,28,20:handle_too_long=compact_overflow:skip_keyword_call=Log:compact_overflow_limit=1",
         )
+
+    def test_skip_return_values_overflow(self):
+        """From https://github.com/MarketSquare/robotframework-tidy/issues/386"""
+        self.compare(
+            source="skip_return_values_overflow.robot",
+            config=":widths=24,28,20:"
+            "handle_too_long=compact_overflow:"
+            "compact_overflow_limit=1:"
+            "skip_return_values=True",
+        )

--- a/tests/e2e/test_transform_stability.py
+++ b/tests/e2e/test_transform_stability.py
@@ -27,6 +27,7 @@ RERUN_NEEDED = {
         "non_ascii_spaces": 2,
         "skip_keywords": 2,
         "overflow_first_line": 2,
+        "skip_return_values_overflow": 2,
     },
     "IndentNestedKeywords": {"run_keyword": 2},
     "InlineIf": {


### PR DESCRIPTION
Fixes #386 