### PR TITLE
Fix duplicated short option name for target robot version

### DIFF
--- a/docs/releasenotes/3.2.rst
+++ b/docs/releasenotes/3.2.rst
@@ -1,4 +1,4 @@
-Robotidy 3.1.0
+Robotidy 3.2.0
 =========================================
 
 You can install the latest available version by running::
@@ -32,6 +32,9 @@ Fixes
   Our help didn't print properly when calling the Robotidy in such a way.
 
 * Fixed fatal exception when running robotidy with only ``NormalizeSeparator`` enabled on FOR loop without closing END (`#390 <https://github.com/MarketSquare/robotframework-tidy/issues/390>`_).
+
+* Renamed invalid short name of ``--target-version`` from ``-t`` (which was duplicate of ``--transform`` short option)
+  to ``--tv`` (`#375 <https://github.com/MarketSquare/robotframework-tidy/issues/375>`_.
 
 Acknowledgements
 -----------------

--- a/robotidy/cli.py
+++ b/robotidy/cli.py
@@ -26,42 +26,42 @@ click.rich_click.STYLE_OPTION_DEFAULT = "grey37"
 click.rich_click.STYLE_OPTIONS_PANEL_BORDER = "grey66"
 click.rich_click.STYLE_USAGE = "magenta"
 CLI_OPTIONS_LIST = [
-        {
-            "name": "Run only selected transformers",
-            "options": ["--transform"],
-        },
-        {
-            "name": "Work modes",
-            "options": ["--overwrite", "--diff", "--check", "--force-order"],
-        },
-        {
-            "name": "Documentation",
-            "options": ["--list", "--desc"],
-        },
-        {
-            "name": "Configuration",
-            "options": ["--configure", "--config"],
-        },
-        {
-            "name": "Global formatting settings",
-            "options": [
-                "--spacecount",
-                "--indent",
-                "--continuation-indent",
-                "--line-length",
-                "--lineseparator",
-                "--separator",
-                "--startline",
-                "--endline",
-            ],
-        },
-        {"name": "File exclusion", "options": ["--exclude", "--extend-exclude", "--skip-gitignore"]},
-        skip.option_group,
-        {
-            "name": "Other",
-            "options": ["--target-version", "--verbose", "--color", "--output", "--version", "--help"],
-        },
-    ]
+    {
+        "name": "Run only selected transformers",
+        "options": ["--transform"],
+    },
+    {
+        "name": "Work modes",
+        "options": ["--overwrite", "--diff", "--check", "--force-order"],
+    },
+    {
+        "name": "Documentation",
+        "options": ["--list", "--desc"],
+    },
+    {
+        "name": "Configuration",
+        "options": ["--configure", "--config"],
+    },
+    {
+        "name": "Global formatting settings",
+        "options": [
+            "--spacecount",
+            "--indent",
+            "--continuation-indent",
+            "--line-length",
+            "--lineseparator",
+            "--separator",
+            "--startline",
+            "--endline",
+        ],
+    },
+    {"name": "File exclusion", "options": ["--exclude", "--extend-exclude", "--skip-gitignore"]},
+    skip.option_group,
+    {
+        "name": "Other",
+        "options": ["--target-version", "--verbose", "--color", "--output", "--version", "--help"],
+    },
+]
 click.rich_click.OPTION_GROUPS = {
     "robotidy": CLI_OPTIONS_LIST,
     "python -m robotidy": CLI_OPTIONS_LIST,
@@ -385,7 +385,7 @@ def print_transformers_list(target_version: int):
 )
 @click.option(
     "--target-version",
-    "-t",
+    "-tv",
     type=click.Choice([v.name.lower() for v in TargetVersion], case_sensitive=False),
     callback=validate_target_version,
     help="Only enable transformers supported in set target version",

--- a/tests/utest/test_cli.py
+++ b/tests/utest/test_cli.py
@@ -58,14 +58,15 @@ class TestCli:
         result = run_tidy(args, exit_code=1)
         assert expected_output == result.output
 
-    def test_not_existing_configurable_similar(self):
+    @pytest.mark.parametrize("option_name", ["-t", "--transform"])
+    def test_not_existing_configurable_similar(self, option_name):
         expected_output = (
             "Error: DiscardEmptySections: Failed to import. "
             "Verify if correct name or configuration was provided. Did you mean:\n"
             "    allow_only_comments\n"
         )
 
-        args = "--transform DiscardEmptySections:allow_only_commentss=True -".split()
+        args = f"{option_name} DiscardEmptySections:allow_only_commentss=True -".split()
         result = run_tidy(args, exit_code=1)
         assert result.output == expected_output
 
@@ -435,17 +436,23 @@ class TestCli:
     def test_invalid_target_version(self, mocked_version, target_version):
         mocked_version.major = 5
         result = run_tidy(f"--target-version {target_version} .".split(), exit_code=2)
-        error = result.output
+        error = self.normalize_cli_error(result.output)
+        assert f"Invalid value for '--target-version' / '-tv':" in error
+
+    def normalize_cli_error(self, error):
         error = error.replace("│", "").replace("\n", "")
-        assert f"Invalid value for '--target-version' / '-t':" in error
+        error = " ".join(error.split())
+        return error
 
     @patch("robotidy.cli.ROBOT_VERSION")
-    def test_too_recent_target_version(self, mocked_version):
+    @pytest.mark.parametrize("option_name", ["-tv", "--target-version"])
+    def test_too_recent_target_version(self, mocked_version, option_name):
         target_version = 5
         mocked_version.major = 4
-        result = run_tidy(f"--target-version rf{target_version} .".split(), exit_code=2)
-        # Split into parts due to rich click putting errors into boxes
-        assert "Invalid value for '--target-version' / '-t':" in result.output
-        assert "Target Robot Framework version" in result.output
-        assert f"({target_version})" in result.output
-        assert "should not be higher than installed version" in result.output
+        result = run_tidy(f"{option_name} rf{target_version} .".split(), exit_code=2)
+        error = self.normalize_cli_error(result.output)
+        assert (
+            "Invalid value for '--target-version' / '-tv': "
+            f"Target Robot Framework version ({target_version}) "
+            "should not be higher than installed version (" in error
+        )


### PR DESCRIPTION
``--target-version`` and ``--transform`` shared the same short name of the option (``-t``). Now ``--target-version`` uses ``-tv``.

I have read on the subject and usually it's not recommended to use more than single character for short name of the option (usually cli tools allow to chains some flags like -l -r can be -lr). But since we're already using two letter short names in both Robocop and Robotidy I went ahead. We don't allow chaining and it's desribed in the docs.

Fixes #375