### PR TITLE
Print transformer parameters in --desc output

### DIFF
--- a/docs/releasenotes/3.2.rst
+++ b/docs/releasenotes/3.2.rst
@@ -11,12 +11,15 @@ or to install exactly this version::
 
 Documentation
 ----------------
-Several fixes and changes to our documentation (thanks to `@glueologist <https://github.com/glueologist>`__ feedback).
 
-Our theme changed from `alabster` to `furo`. Thanks for that it will be consistent across our other tools (like Robocop),
-it's a bit prettier (night mode!) and more customizable.
+* Several fixes and changes to our documentation (thanks to `@glueologist <https://github.com/glueologist>`__ feedback).
+* Our theme changed from `alabster` to `furo`. Thanks for that it will be consistent across our other tools (like Robocop),
+  it's a bit prettier (night mode!) and more customizable.
+* Transformer parameters and their default values are now listed transformer short docs
+  (invoked via ``--desc name``) (`#377 <https://github.com/MarketSquare/robotframework-tidy/issues/377>`_).
+* Transformers in the ``--list`` and ``-desc all`` command outputs are now listed in the order they are run by default
 
-Related issues and PRs:
+Other related issues and PRs:
 
  - `#367 <https://github.com/MarketSquare/robotframework-tidy/issues/367>`_
  - `#369 <https://github.com/MarketSquare/robotframework-tidy/issues/369>`_

--- a/robotidy/config.py
+++ b/robotidy/config.py
@@ -81,14 +81,23 @@ class Config:
         self.output = output
         self.color = color
         transformers_config = self.convert_configure(transformers_config)
-        self.transformers = load_transformers(
-            transformers, transformers_config, force_order=force_order, target_version=target_version, skip=skip
+        self.transformers = self.get_transformers_instances(
+            transformers, transformers_config, force_order, target_version, skip
         )
         transformer_map = {transformer.__class__.__name__: transformer for transformer in self.transformers}
         for transformer in self.transformers:
             # inject global settings TODO: handle it better
             setattr(transformer, "formatting_config", self.formatting)
             setattr(transformer, "transformers", transformer_map)
+
+    @staticmethod
+    def get_transformers_instances(transformers, transformers_config, force_order, target_version, skip):
+        return [
+            transformer.instance
+            for transformer in load_transformers(
+                transformers, transformers_config, force_order=force_order, target_version=target_version, skip=skip
+            )
+        ]
 
     @staticmethod
     def convert_configure(configure: List[Tuple[str, List]]) -> Dict[str, List]:

--- a/tests/e2e/test_transform_stability.py
+++ b/tests/e2e/test_transform_stability.py
@@ -88,10 +88,9 @@ def get_enable_disabled_config() -> List[str]:
     )
     config = []
     for transformer in transformers:
-        if not is_transformer_disabled(transformer):
+        if not is_transformer_disabled(transformer.instance):
             continue
-        name = transformer.__class__.__name__
-        config.extend(["--configure", f"{name}:enabled=True"])
+        config.extend(["--configure", f"{transformer.name}:enabled=True"])
     return config
 
 

--- a/tests/utest/test_load_transformers.py
+++ b/tests/utest/test_load_transformers.py
@@ -22,7 +22,7 @@ class TestLoadTransformers:
         transformers_2 = load_transformers(
             [(transf, []) for transf in order_2], {}, skip=skip_config, target_version=ROBOT_VERSION.major
         )
-        assert all(t1.__class__.__name__ == t2.__class__.__name__ for t1, t2 in zip(transformers_1, transformers_2))
+        assert all(t1.name == t2.name for t1, t2 in zip(transformers_1, transformers_2))
 
     def test_transformer_force_order(self, skip_config):
         # default_order = ['NormalizeSeparators', 'OrderSettings']
@@ -34,17 +34,17 @@ class TestLoadTransformers:
             force_order=True,
             target_version=ROBOT_VERSION.major,
         )
-        assert all(t1.__class__.__name__ == t2 for t1, t2 in zip(transformers, custom_order))
+        assert all(t1.name == t2 for t1, t2 in zip(transformers, custom_order))
 
     def test_disabled_transformer(self, skip_config):
         transformers = load_transformers(None, {}, skip=skip_config, target_version=ROBOT_VERSION.major)
-        assert all(transformer.__class__.__name__ != "SmartSortKeywords" for transformer in transformers)
+        assert all(transformer.name != "SmartSortKeywords" for transformer in transformers)
 
     def test_enable_disable_transformer(self, skip_config):
         transformers = load_transformers(
             [("SmartSortKeywords", [])], {}, skip=skip_config, target_version=ROBOT_VERSION.major
         )
-        assert transformers[0].__class__.__name__ == "SmartSortKeywords"
+        assert transformers[0].name == "SmartSortKeywords"
 
     def test_configure_transformer(self, skip_config):
         transformers = load_transformers(
@@ -53,8 +53,8 @@ class TestLoadTransformers:
         transformers_not_configured = load_transformers(None, {}, skip=skip_config, target_version=ROBOT_VERSION.major)
         assert len(transformers) == len(transformers_not_configured)
         for transformer in transformers:
-            if transformer.__class__.__name__ == "AlignVariablesSection":
-                assert transformer.up_to_column + 1 == 4
+            if transformer.name == "AlignVariablesSection":
+                assert transformer.instance.up_to_column + 1 == 4
 
     def test_configure_transformer_overwrite(self, skip_config):
         transformers = load_transformers(
@@ -63,7 +63,7 @@ class TestLoadTransformers:
             skip=skip_config,
             target_version=ROBOT_VERSION.major,
         )
-        assert transformers[0].up_to_column + 1 == 4
+        assert transformers[0].instance.up_to_column + 1 == 4
 
     @pytest.mark.parametrize("force_order", [True, False])
     @pytest.mark.parametrize("allow_disabled", [True, False])
@@ -139,9 +139,9 @@ class TestLoadTransformers:
             target_version=ROBOT_VERSION.major,
         )
         if present:
-            assert any(transformer.__class__.__name__ == test_for for transformer in loaded_transformers)
+            assert any(transformer.name == test_for for transformer in loaded_transformers)
         else:
-            assert all(transformer.__class__.__name__ != test_for for transformer in loaded_transformers)
+            assert all(transformer.name != test_for for transformer in loaded_transformers)
 
     @pytest.mark.parametrize("target_version", [4, 5, None])
     @pytest.mark.parametrize("version", [4, 5])
@@ -179,7 +179,7 @@ class TestLoadTransformers:
         mocked_version = Mock(major=version)
         with patch("robotidy.transformers.ROBOT_VERSION", mocked_version):
             transformers = load_transformers(transform, config, skip=skip_config, target_version=target_version)
-        transformers_names = sorted([transformer.__class__.__name__ for transformer in transformers])
+        transformers_names = sorted([transformer.name for transformer in transformers])
         if expected_transformers == ["all_default"]:
             only_5_found = any(
                 name in {"InlineIf", "ReplaceBreakContinue", "ReplaceReturns"} for name in transformers_names


### PR DESCRIPTION
Main change was to store transformer in container class to keep transformer metadata. This allowed us to:

  * print transformer parameters and their defaults (Closes #377)
  * print transformers in the order they are run
  * make some preparation for future refactor of the importing module w- it's getting bit messy!
 