### PR TITLE
Use packaging specifier set for tests target version

### DIFF
--- a/tests/atest/transformers/AddMissingEnd/test_transformer.py
+++ b/tests/atest/transformers/AddMissingEnd/test_transformer.py
@@ -15,7 +15,7 @@ class TestAddMissingEnd(TransformerAcceptanceTest):
         )
 
     def test_rf5_syntax(self):
-        self.compare(source="test_5.robot", target_version=5)
+        self.compare(source="test_5.robot", target_version=">=5")
 
     def test_disablers(self):
-        self.compare(source="test_5_disablers.robot", target_version=5, not_modified=True)
+        self.compare(source="test_5_disablers.robot", target_version=">=5", not_modified=True)

--- a/tests/atest/transformers/AlignKeywordsSection/test_transformer.py
+++ b/tests/atest/transformers/AlignKeywordsSection/test_transformer.py
@@ -18,13 +18,13 @@ class TestAlignKeywordsSection(TransformerAcceptanceTest):
         self.compare(source="blocks.robot", expected="blocks_auto_0.robot", config=":alignment_type=auto:widths=0")
 
     def test_blocks_rf5(self):
-        self.compare(source="blocks_rf5.robot", target_version=5)
+        self.compare(source="blocks_rf5.robot", target_version=">=5")
 
     def test_one_column(self):
         self.compare(source="one_column.robot")
 
     def test_invalid(self):
-        self.compare(source="non_ascii_spaces.robot", target_version=5)
+        self.compare(source="non_ascii_spaces.robot", target_version=">=5")
 
     @pytest.mark.parametrize(
         "widths",
@@ -93,7 +93,7 @@ class TestAlignKeywordsSection(TransformerAcceptanceTest):
         self.compare(source="too_long_line.robot", config=" --transform SplitTooLongLine")
 
     def test_error_node(self):
-        self.compare(source="error_node.robot", not_modified=True, target_version=5)
+        self.compare(source="error_node.robot", not_modified=True, target_version=">=5")
 
     def test_skip_return_values(self):
         self.compare(

--- a/tests/atest/transformers/AlignTestCasesSection/test_transformer.py
+++ b/tests/atest/transformers/AlignTestCasesSection/test_transformer.py
@@ -18,13 +18,13 @@ class TestAlignTestCasesSection(TransformerAcceptanceTest):
         self.compare(source="blocks.robot", expected="blocks_auto_0.robot", config=":alignment_type=auto:widths=0")
 
     def test_blocks_rf5(self):
-        self.compare(source="blocks_rf5.robot", target_version=5)
+        self.compare(source="blocks_rf5.robot", target_version=">=5")
 
     def test_one_column(self):
         self.compare(source="one_column.robot")
 
     def test_invalid(self):
-        self.compare(source="non_ascii_spaces.robot", target_version=5)
+        self.compare(source="non_ascii_spaces.robot", target_version=">=5")
 
     @pytest.mark.parametrize(
         "widths",

--- a/tests/atest/transformers/MergeAndOrderSections/test_merge_and_order_sections.py
+++ b/tests/atest/transformers/MergeAndOrderSections/test_merge_and_order_sections.py
@@ -75,4 +75,4 @@ class TestMergeAndOrderSections(TransformerAcceptanceTest):
         self.compare(source="disablers.robot")
 
     def test_translated(self):
-        self.compare(source="translated.robot", target_version=6)
+        self.compare(source="translated.robot", target_version=">=6")

--- a/tests/atest/transformers/NormalizeNewLines/test_normalize_new_lines.py
+++ b/tests/atest/transformers/NormalizeNewLines/test_normalize_new_lines.py
@@ -49,19 +49,21 @@ class TestNormalizeNewLines(TransformerAcceptanceTest):
 
     @pytest.mark.parametrize("trailing_lines", [0, 1, 2])
     def test_inline_if(self, trailing_lines):
-        self.compare(source=f"inline_if_{trailing_lines}_lines.robot", expected="inline_if.robot", target_version=5)
+        self.compare(source=f"inline_if_{trailing_lines}_lines.robot", expected="inline_if.robot", target_version=">=5")
 
     def test_disablers(self):
         self.compare(source="disablers.robot", not_modified=True)
 
     def test_blocks(self):
-        self.compare(source="blocks.robot", target_version=5)
+        self.compare(source="blocks.robot", target_version=">=5")
 
     def test_remove_empty_multiline(self):
         self.compare(source="multiline.robot")
 
     def test_language_header(self):
-        self.compare(source="language_header_0empty.robot", target_version=6)
-        self.compare(source="language_header_2empty.robot", target_version=6)
-        self.compare(source="language_header_5empty.robot", expected="language_header_2empty.robot", target_version=6)
-        self.compare(source="language_header_and_comments.robot", target_version=6)
+        self.compare(source="language_header_0empty.robot", target_version=">=6")
+        self.compare(source="language_header_2empty.robot", target_version=">=6")
+        self.compare(
+            source="language_header_5empty.robot", expected="language_header_2empty.robot", target_version=">=6"
+        )
+        self.compare(source="language_header_and_comments.robot", target_version=">=6")

--- a/tests/atest/transformers/NormalizeSectionHeaderName/test_normalize_section_header.py
+++ b/tests/atest/transformers/NormalizeSectionHeaderName/test_normalize_section_header.py
@@ -23,4 +23,4 @@ class TestNormalizeSectionHeaderName(TransformerAcceptanceTest):
         self.compare(source="disablers.robot", not_modified=True)
 
     def test_translated(self):
-        self.compare(source="translated.robot", target_version=6)
+        self.compare(source="translated.robot", target_version=">=6")

--- a/tests/atest/transformers/NormalizeSeparators/test_transformer.py
+++ b/tests/atest/transformers/NormalizeSeparators/test_transformer.py
@@ -41,7 +41,7 @@ class TestNormalizeSeparators(TransformerAcceptanceTest):
         assert expected_output == result.output
 
     def test_rf5_syntax(self):
-        self.compare(source="rf5_syntax.robot", target_version=5)
+        self.compare(source="rf5_syntax.robot", target_version=">=5")
 
     def test_disablers(self):
         self.compare(source="disablers.robot", not_modified=True)
@@ -64,7 +64,7 @@ class TestNormalizeSeparators(TransformerAcceptanceTest):
             expected=f"inline_if_{indent}indent_{spaces}spaces.robot",
             config=f" --spacecount {spaces} --indent {indent}",
             not_modified=not_modified,
-            target_version=5,
+            target_version=">=5",
         )
 
     def test_skip_keyword_call(self):
@@ -85,4 +85,4 @@ class TestNormalizeSeparators(TransformerAcceptanceTest):
             expected = "comments_skip_comments.robot"
         else:
             expected = "comments_skip_block_comments.robot"
-        self.compare(source="comments.robot", expected=expected, config=config, target_version=5)
+        self.compare(source="comments.robot", expected=expected, config=config, target_version=">=5")

--- a/tests/atest/transformers/NormalizeSettingName/test_normalize_setting_name.py
+++ b/tests/atest/transformers/NormalizeSettingName/test_normalize_setting_name.py
@@ -18,4 +18,4 @@ class TestNormalizeSettingName(TransformerAcceptanceTest):
         self.compare(source="disablers.robot", not_modified=True)
 
     def test_translated(self):
-        self.compare(source="translated.robot", target_version=6)
+        self.compare(source="translated.robot", target_version=">=6")

--- a/tests/atest/transformers/OrderSettings/test_order_settings.py
+++ b/tests/atest/transformers/OrderSettings/test_order_settings.py
@@ -84,4 +84,4 @@ class TestOrderSettings(TransformerAcceptanceTest):
         assert result.output == expected_output
 
     def test_translated(self):
-        self.compare(source="translated.robot", target_version=6)
+        self.compare(source="translated.robot", target_version=">=6")

--- a/tests/atest/transformers/SplitTooLongLine/test_transformer.py
+++ b/tests/atest/transformers/SplitTooLongLine/test_transformer.py
@@ -9,7 +9,7 @@ class TestSplitTooLongLine(TransformerAcceptanceTest):
             source="tests.robot",
             expected="feed_until_line_length.robot",
             config=":line_length=80:split_on_every_arg=False -s 4",
-            target_version=5,
+            target_version=">=5",
         )
 
     def test_split_too_long_lines_4(self):
@@ -17,17 +17,23 @@ class TestSplitTooLongLine(TransformerAcceptanceTest):
             source="tests.robot",
             expected="feed_until_line_length_4.robot",
             config=":line_length=80:split_on_every_arg=False -s 4",
-            target_version=4,
+            target_version="==4",
         )
 
     def test_split_too_long_lines_split_on_every_arg(self):
         self.compare(
-            source="tests.robot", expected="split_on_every_arg.robot", config=":line_length=80 -s 4", target_version=5
+            source="tests.robot",
+            expected="split_on_every_arg.robot",
+            config=":line_length=80 -s 4",
+            target_version=">=5",
         )
 
     def test_split_too_long_lines_split_on_every_arg_4(self):
         self.compare(
-            source="tests.robot", expected="split_on_every_arg_4.robot", config=":line_length=80 -s 4", target_version=4
+            source="tests.robot",
+            expected="split_on_every_arg_4.robot",
+            config=":line_length=80 -s 4",
+            target_version="==5",
         )
 
     def test_split_lines_with_multiple_assignments(self):
@@ -51,20 +57,20 @@ class TestSplitTooLongLine(TransformerAcceptanceTest):
         )
 
     def test_disablers(self):
-        self.compare(source="disablers.robot", config=":line_length=80", not_modified=True, target_version=5)
+        self.compare(source="disablers.robot", config=":line_length=80", not_modified=True, target_version=">=5")
 
     def test_continuation_indent(self):
         self.compare(
             source="continuation_indent.robot",
             expected="continuation_indent_feed.robot",
             config=":line_length=80:split_on_every_arg=False -s 2 --continuation-indent 4 --indent 2",
-            target_version=5,
+            target_version=">=5",
         )
         self.compare(
             source="continuation_indent.robot",
             expected="continuation_indent_split.robot",
             config=":line_length=80:split_on_every_arg=True -s 2 --continuation-indent 4 --indent 2",
-            target_version=5,
+            target_version=">=5",
         )
 
     def test_variables_split(self):
@@ -86,5 +92,5 @@ class TestSplitTooLongLine(TransformerAcceptanceTest):
             source="tests.robot",
             expected="skip_keywords.robot",
             config=":line_length=80:skip_keyword_call=thisisakeyword:skip_keyword_call_pattern=(i?)sets\sthe\svariable",
-            target_version=5,
+            target_version=">=5",
         )

--- a/tests/atest/transformers/__init__.py
+++ b/tests/atest/transformers/__init__.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 import pytest
 from click.testing import CliRunner
+from packaging.specifiers import SpecifierSet
 from rich.console import Console
 
 from robotidy.cli import cli
@@ -43,7 +44,7 @@ class TransformerAcceptanceTest:
         not_modified: bool = False,
         expected: Optional[str] = None,
         config: str = "",
-        target_version: Optional[int] = None,
+        target_version: Optional[str] = None,
     ):
         """
         Compare actual (source) and expected files. If expected filename is not provided it's assumed to be the same
@@ -52,7 +53,7 @@ class TransformerAcceptanceTest:
         Use not_modified flag if the content of the file shouldn't be modified by transformer.
         """
         if not self.enabled_in_version(target_version):
-            pytest.skip(f"Test enabled only for RF {target_version}.0")
+            pytest.skip(f"Test enabled only for RF {target_version}")
         if expected is None:
             expected = source
         self.run_tidy(
@@ -91,8 +92,8 @@ class TransformerAcceptanceTest:
             display_file_diff(expected, actual)
             pytest.fail(f"File {actual_name} is not same as expected")
 
-    def enabled_in_version(self, target_version: Optional[int]) -> bool:
-        if target_version and ROBOT_VERSION.major != target_version:
+    def enabled_in_version(self, target_version: Optional[str]) -> bool:
+        if target_version and ROBOT_VERSION not in SpecifierSet(target_version, prereleases=True):
             return False
         if self.TRANSFORMER_NAME in VERSION_MATRIX:
             return ROBOT_VERSION.major >= VERSION_MATRIX[self.TRANSFORMER_NAME]


### PR DESCRIPTION
Previous solution was flawed - with new major RF version release test set for given version didn't run for new. SpecifierSet allow more flexible approach for defining the test target version.