### PR TITLE
Fix whitespace in keyword names consisting only of robot variable

### DIFF
--- a/docs/releasenotes/3.3.3.rst
+++ b/docs/releasenotes/3.3.3.rst
@@ -1,0 +1,16 @@
+Robotidy 3.3.3
+=========================================
+Fix release addressing invalid handling of run keywords in ``RenameKeywords`` transformer.
+
+You can install the latest available version by running::
+
+    pip install --upgrade robotframework-tidy
+
+or to install exactly this version::
+
+    pip install robotframework-tidy==3.3.3
+
+Fixes
+------
+
+- ``RenameKeywords`` now does not insert extra space before variable used for keyword name in Run Keyword variant (#439)

--- a/robotidy/transformers/RenameKeywords.py
+++ b/robotidy/transformers/RenameKeywords.py
@@ -114,7 +114,7 @@ class RenameKeywords(ModelTransformer):
             if remaining.startswith(" "):
                 parts.append(" ")
             parts.append(self.rename_part(remaining, is_keyword_call))
-            return "".join(parts)
+            return "".join(parts).strip()
         return self.rename_part(value, is_keyword_call)
 
     def rename_part(self, part: str, is_keyword_call: bool):

--- a/robotidy/transformers/RenameKeywords.py
+++ b/robotidy/transformers/RenameKeywords.py
@@ -99,10 +99,12 @@ class RenameKeywords(ModelTransformer):
         var_found = False
         parts = []
         new_name, remaining = "", ""
+        if value.strip() == "${keyword}":
+            print()
         for prefix, match, remaining in VariableIterator(value, ignore_errors=True):
             var_found = True
             # rename strips whitespace, so we need to preserve it if needed
-            if not prefix.strip():
+            if not prefix.strip() and parts:
                 parts.extend([" ", match])
             else:
                 leading_space = " " if prefix.startswith(" ") else ""

--- a/robotidy/transformers/SplitTooLongLine.py
+++ b/robotidy/transformers/SplitTooLongLine.py
@@ -56,17 +56,18 @@ class SplitTooLongLine(Transformer):
 
     ```robotframework
     *** Test Cases ***
-    Test with default split_on_every_arg
-        # ${arg1} fits under limit, so it stays in the line
-        Keyword With Longer Name    ${arg1}
-        ...    ${arg2}    ${arg3}
-
-    Test with split_on_every_arg = False
+    Test with split_on_every_arg = True (default)
         # arguments are split
         Keyword With Longer Name
         ...    ${arg1}
         ...    ${arg2}
         ...    ${arg3}
+
+    Test with split_on_every_arg = False
+        # ${arg1} fits under limit, so it stays in the line
+        Keyword With Longer Name    ${arg1}
+        ...    ${arg2}    ${arg3}
+
     ```
 
     Supports global formatting params: ``spacecount`` and ``separator``.

--- a/tests/atest/transformers/RenameKeywords/expected/embedded_variables.robot
+++ b/tests/atest/transformers/RenameKeywords/expected/embedded_variables.robot
@@ -14,3 +14,10 @@ Multiple In A Row
 
 Empty Space After Last Variable
     Embedded ${variable} And Space
+
+Embedded Last
+    Embedded ${variable}
+    Embedded ${variable}    ${argument}
+
+Run Keyword
+    Run Keywords     ${keyword}

--- a/tests/atest/transformers/RenameKeywords/source/embedded_variables.robot
+++ b/tests/atest/transformers/RenameKeywords/source/embedded_variables.robot
@@ -14,3 +14,10 @@ Multiple In A Row
 
 Empty Space After Last Variable
     Embedded ${variable} And Space
+
+Embedded Last
+    Embedded ${variable}
+    Embedded ${variable}    ${argument}
+
+Run Keyword
+    Run Keywords     ${keyword}


### PR DESCRIPTION
Fixes #439 