### PR TITLE
Skip comments in SplitTooLongLine transformer

### DIFF
--- a/docs/releasenotes/3.4.0.rst
+++ b/docs/releasenotes/3.4.0.rst
@@ -63,6 +63,33 @@ Support for the other setting will be added in the next releases.
 It is possible to configure how arguments in settings will be split using ``split_on_every_setting_arg`` parameter.
 Read more `in the documentation<https://robotidy.readthedocs.io/en/stable/transformers/SplitTooLongLine.html#split-settings-arguments-on-every-line>`_.
 
+Comments in the lines
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If your line contains comments it can be recognized as too long. It may lead to producing less readable output, like
+the one below:
+
+From::
+
+    ${VARIABLE_01}                                  a_value    # a short one-liner description for variable that goes over
+
+To::
+
+    # a short one-liner description for variable that goes over
+    ${VARIABLE_01}
+    ...    a_value
+
+The value will be split to the new line even if it does not help readability since comment was moved before the
+variable.
+Now it is possible to ignore comments in ``SplitTooLongLine`` by using skip comment option::
+
+    robotidy -c SplitTooLongLine:skip_comments=True <src>
+    # or global option that skips formatting comments in all transformers
+    robotidy --skip-comments <src>
+
+In the previous code the line will now not be formatted since the line will not be recognized as too long (length of the
+comment is removed from calculated line length).
+
 Support for Python 3.11
 -------------------------
 

--- a/docs/source/transformers/SplitTooLongLine.rst
+++ b/docs/source/transformers/SplitTooLongLine.rst
@@ -185,6 +185,15 @@ Assignments will be split to multi lines if they don't fit together with Keyword
                 ...    ${arg1}
                 ...    ${arg2}
 
+Ignore comments
+----------------
+
+To not count length of the comment to line length use :ref:`skip comments` option::
+
+    robotidy --configure SplitTooLongLine:skip_comments=True <src>
+
+This allows to accept and do not format lines that are longer than allowed length because of the added comment.
+
 Skip formatting
 ----------------
 It is possible to use the following arguments to skip formatting of the code:
@@ -192,6 +201,7 @@ It is possible to use the following arguments to skip formatting of the code:
 - :ref:`skip keyword call`
 - :ref:`skip keyword call pattern`
 - :ref:`skip settings`
+- :ref:`skip comments`
 
 It is also possible to use disablers (:ref:`disablers`) but ``skip`` option
 makes it easier to skip all instances of given type of the code.


### PR DESCRIPTION
The change was already included in #460 but it wasn't mentioned in the documentation.

Closes #456