### PR TITLE
Add rerun in place option

### DIFF
--- a/docs/releasenotes/3.6.0.rst
+++ b/docs/releasenotes/3.6.0.rst
@@ -1,0 +1,33 @@
+Robotidy 3.6.0
+=========================================
+
+
+You can install the latest available version by running::
+
+    pip install --upgrade robotframework-tidy
+
+or to install exactly this version::
+
+    pip install robotframework-tidy==3.6.0
+
+Rerun the transformation in place
+----------------------------------
+
+Because of high independence of each transformer, Robotidy runs them in specific order to obtain predictable results.
+But sometimes the subsequent transformer modifies the file to the point that it requires another run of Robotidy.
+Good example would be one transformer that replaces the deprecated syntax - but new syntax is inserted using standard
+whitespace. If there is transformer that aligns this whitespace according to special rules (like ``AlignKeywordsSection``)
+we need to run Robotidy again to format this whitespace.
+
+This could be inconvenient in some cases where user had to rerun Robotidy without knowing why. That's why Robotidy
+now has new option ``reruns`` that allows to define limit of how many extra reruns Robotidy can perform if the
+file keeps changing after the transformation. The default is ``0`` (original behaviour). Recommended value is ``3``
+although in vast majority of cases one extra run should suffice (and only in cases described above).
+
+Example usage::
+
+    robotidy --reruns 3 --diff test.robot
+
+Note that if you enable it, it can double the execution time of Robotidy (if the file was modified, it will be
+transformed again to check if next transformation does not further modify the file). It should be not a problem because
+Robotidy is fast enough but report any issues with this feature.

--- a/robotidy/api.py
+++ b/robotidy/api.py
@@ -64,6 +64,7 @@ def get_robotidy(src: str, output: Optional[str], **kwargs):
     formatting_config = get_formatting_config(config, kwargs)
     exclude = config.get("exclude", None)
     extend_exclude = config.get("extend_exclude", None)
+    reruns = config.get("reruns", 0)
     exclude = utils.validate_regex(exclude if exclude is not None else files.DEFAULT_EXCLUDES)
     extend_exclude = utils.validate_regex(extend_exclude)
     global_skip = get_skip_config(config)
@@ -86,6 +87,7 @@ def get_robotidy(src: str, output: Optional[str], **kwargs):
         target_version=utils.ROBOT_VERSION.major,
         color=False,
         language=language,
+        reruns=reruns,
     )
     return app.Robotidy(config=configuration)
 

--- a/robotidy/cli.py
+++ b/robotidy/cli.py
@@ -447,6 +447,13 @@ def print_transformers_list(
     help="Parse Robot Framework files using additional languages.",
     show_default="en",
 )
+@click.option(
+    "--reruns",
+    "-r",
+    type=int,
+    help="Robotidy will rerun the transformations up to reruns times until the code stop changing.",
+    show_default="0",
+)
 @skip.comments_option
 @skip.documentation_option
 @skip.return_values_option
@@ -492,6 +499,7 @@ def cli(
     force_order: bool,
     target_version: int,
     language: Optional[List[str]],
+    reruns: int,
     skip_comments: bool,
     skip_documentation: bool,
     skip_return_values: bool,
@@ -576,6 +584,7 @@ def cli(
         target_version=target_version,
         color=color,
         language=language,
+        reruns=reruns,
     )
 
     if list_transformers:

--- a/robotidy/config.py
+++ b/robotidy/config.py
@@ -77,6 +77,7 @@ class Config:
         target_version: int,
         color: bool,
         language: Optional[List[str]],
+        reruns: int,
     ):
         self.sources = get_paths(src, exclude, extend_exclude, skip_gitignore)
         self.formatting = formatting
@@ -86,6 +87,7 @@ class Config:
         self.check = check
         self.output = output
         self.color = color
+        self.reruns = reruns
         self.language = self.get_languages(language)
         transformers_config = self.convert_configure(transformers_config)
         self.transformers = []

--- a/tests/e2e/test_transform_stability.py
+++ b/tests/e2e/test_transform_stability.py
@@ -71,8 +71,8 @@ def run_tidy(cmd, enable_disabled: bool):
     return runner.invoke(cli, cmd)
 
 
-def run_with_source(source: Path, enable_disabled: bool):
-    cmd = [str(source)]
+def run_with_source(source: Path, enable_disabled: bool, reruns: int):
+    cmd = ["--reruns", str(reruns), str(source)]
     result = run_tidy(cmd, enable_disabled)
     if result.exit_code != 0:
         raise AssertionError(f"Run failed for {source}")
@@ -178,8 +178,7 @@ def test_stability_of_transformation(tmpdir, test_file, enable_disabled):
     # copy test data to temp directory
     test_data_dst = tmpdir / test_file.name
     shutil.copy(test_file, test_data_dst)
-    for _ in range(reruns):
-        run_with_source(test_data_dst, enable_disabled)
+    run_with_source(test_data_dst, enable_disabled, reruns)
     for _ in range(2):
         # rerun with --check twice to confirm stability
         run_with_source_and_check(test_data_dst, test_file, enable_disabled)

--- a/tests/utest/test_utils.py
+++ b/tests/utest/test_utils.py
@@ -40,6 +40,7 @@ def app():
         target_version=ROBOT_VERSION.major,
         color=True,
         language=None,
+        reruns=1,
     )
     return Robotidy(
         config=config,


### PR DESCRIPTION
This option resolves one of the oldest problems in Robotidy - that sometimes you need to rerun whole tool multiple times since the code keeps changing between runs. This PR introduces new option, --reruns, that allow to configure number of reruns that Robotidy will perform in place until the code stops changing.