### PR TITLE
Load custom transformer on top of default ones

### DIFF
--- a/docs/releasenotes/3.6.0.rst
+++ b/docs/releasenotes/3.6.0.rst
@@ -26,8 +26,25 @@ although in vast majority of cases one extra run should suffice (and only in cas
 
 Example usage::
 
-    robotidy --reruns 3 --diff test.robot
+    > robotidy --reruns 3 --diff test.robot
 
 Note that if you enable it, it can double the execution time of Robotidy (if the file was modified, it will be
 transformed again to check if next transformation does not further modify the file). It should be not a problem because
 Robotidy is fast enough but report any issues with this feature.
+
+Load custom transformers together with defaults
+------------------------------------------------
+
+Previously Robotidy only supported importing custom transformers with ``--transform`` option. This option disables
+any other transformer not listed with ``--transform``. That's why if user would run following::
+
+    > robotidy --transform MyCustomClass.py test.robot
+
+It would disable all default transformers and only run MyCustomClass.
+This release introduces new option ``--load-transformer`` which imports custom transformers on top of the default ones::
+
+    > robotidy --load-transformer MyCustomClass.py test.robot
+
+It is also possible to pass transformer configuration either using this option or through ``--configure``::
+
+    > robotidy -c ExtClass1.py:param=value --load-transformer ExtClass2.py:param2=value test.robot

--- a/docs/source/configuration/configuring_transformers.rst
+++ b/docs/source/configuration/configuring_transformers.rst
@@ -3,15 +3,25 @@
 Configuring Transformers
 ========================
 
-Transformers can be configured through two different options: ``--transform`` (``-t``) and ``--configure`` (``-c``). They share the same
-syntax for parameter names and values. The main difference is that ``--transform`` is also used to select what
-transformers will be used. For example::
+Transformers can be configured through three different options: ``--transform`` (``-t``), ``--load-transformer`` and
+``--configure`` (``-c``). They share the same syntax for parameter names and values.
+
+- ``--configure`` simply provides the configuration to the transformer,
+- ``--transform`` is used to include only transformers that have ``--transform`` option,
+- ``--load-transformer`` is used to load user transformers. Read more at :ref:`external-transformers`.
+
+For example::
 
     robotidy --transform NormalizeNewLines:test_case_lines=2 src
     robotidy --configure NormalizeNewLines:test_case_lines=2 src
+    robotidy --configure NormalizeNewLines:test_case_lines=1 --load-transformer MyCustomTransformer.py:param=value src
 
 With first command robotidy will run only ``NormalizeNewLines`` transformer and it will configure it with ``test_case_lines = 2``.
+
 Second command robotidy will run all of the transformers and will configure ``NormalizeNewLines`` with ``test_case_lines = 2``.
+
+Third command will run all of the transformers, configure ``NormalizeNewLines`` with ``test_case_lines = 1`` and
+import user transformer ``MyCustomTransformer`` with `param=value` configuration.
 
 You can also run all transformers except selected ones. For that you need to configure transformer you want to exclude
 with ``enabled`` parameter::

--- a/docs/source/external_transformers.rst
+++ b/docs/source/external_transformers.rst
@@ -7,8 +7,13 @@ file with class to run external transformers with *robotidy*::
 
     robotidy --transform MyTransformers.YourCustomTransformer src
     robotidy --transform C:\transformers\YourCustomTransformer2.py src
+    robotidy --load-transformer C:\transformers\YourCustomTransformer2.py src
 
 External transformers can be configured in the same way internal transformers are configured - see :ref:`configuring-transformers`.
+
+You can use both ``--transform`` and ``--load-transformer`` options to load custom user transformer. The main difference
+is that ``--transform`` works like include and will only run transformers listed with ``--transform``. While ``--load-transformer``
+will run default transformers first and then user transformers.
 
 You can use the same syntax ``robotidy`` is using for developing internal transformers. The name of the file should
 be the same as name of the class containing your transformer. Your transformer should inherit from ``robot.api.parsing.ModelTransformer``
@@ -60,10 +65,6 @@ class:
 
 
     class ExternalTransformer(Transformer):
-        def __init__(self):
-            super().__init__()
+        pass
 
 ``Transformer`` also inherits from ``ModelTransformer`` but provides more utility methods (and better lint support).
-However because of how we are dynamically loading class arguments from cli/config we need to make a call to
-``super().__init__()`` even if our class don't have any arguments to set. If you're unsure what to use - use
-``ModelTransformer``.

--- a/robotidy/api.py
+++ b/robotidy/api.py
@@ -54,13 +54,17 @@ def get_formatting_config(config, kwargs):
 
 
 def get_robotidy(src: str, output: Optional[str], **kwargs):
+    def convert_transformers_config(param_name, config):
+        return [converter.convert(tr, None, None) for tr in config.get(param_name, ())]
+
     # TODO Refactor - Config should be read in one place both for API and CLI
     # TODO Remove kwargs usage - other SDKs are not using this feature
     config = files.find_and_read_config((src,))
     config = {k: str(v) if not isinstance(v, (list, dict)) else v for k, v in config.items()}
     converter = transformers.TransformType()
-    transformer_list = [converter.convert(tr, None, None) for tr in config.get("transform", ())]
-    configurations = [converter.convert(c, None, None) for c in config.get("configure", ())]
+    transformer_list = convert_transformers_config("transform", config)
+    custom_transformers = convert_transformers_config("load-transformers", config)
+    configurations = convert_transformers_config("configure", config)
     formatting_config = get_formatting_config(config, kwargs)
     exclude = config.get("exclude", None)
     extend_exclude = config.get("extend_exclude", None)
@@ -71,6 +75,7 @@ def get_robotidy(src: str, output: Optional[str], **kwargs):
     language = config.get("language", None)
     configuration = Config(
         transformers=transformer_list,
+        custom_transformers=custom_transformers,
         transformers_config=configurations,
         skip=global_skip,
         src=(),

--- a/robotidy/config.py
+++ b/robotidy/config.py
@@ -63,6 +63,7 @@ class Config:
         formatting: FormattingConfig,
         skip,
         transformers: List[Tuple[str, List]],
+        custom_transformers: List[Tuple[str, List]],
         transformers_config: List[Tuple[str, List]],
         src: Tuple[str, ...],
         exclude: Optional[Pattern],
@@ -92,11 +93,20 @@ class Config:
         transformers_config = self.convert_configure(transformers_config)
         self.transformers = []
         self.transformers_lookup = dict()
-        self.load_transformers(transformers, transformers_config, force_order, target_version, skip)
+        self.load_transformers(
+            transformers, custom_transformers, transformers_config, force_order, target_version, skip
+        )
 
-    def load_transformers(self, transformers, transformers_config, force_order, target_version, skip):
+    def load_transformers(
+        self, transformers, custom_transformers, transformers_config, force_order, target_version, skip
+    ):
         transformers = load_transformers(
-            transformers, transformers_config, force_order=force_order, target_version=target_version, skip=skip
+            transformers,
+            custom_transformers,
+            transformers_config,
+            force_order=force_order,
+            target_version=target_version,
+            skip=skip,
         )
         for transformer in transformers:
             # inject global settings TODO: handle it better

--- a/tests/atest/transformers/ExternalTransformer/ExternalDisabledTransformer.py
+++ b/tests/atest/transformers/ExternalTransformer/ExternalDisabledTransformer.py
@@ -1,0 +1,15 @@
+from robotidy.transformers import Transformer
+
+
+class ExternalDisabledTransformer(Transformer):
+    """
+    This transformer is disabled by default. If it is enabled, it replaces setting names to lowercase.
+    """
+
+    ENABLED = False
+
+    def visit_SectionHeader(self, node):  # noqa
+        if not node.name:
+            return node
+        node.data_tokens[0].value = node.data_tokens[0].value.lower()
+        return node

--- a/tests/atest/transformers/ExternalTransformer/expected/tests_lowercase.robot
+++ b/tests/atest/transformers/ExternalTransformer/expected/tests_lowercase.robot
@@ -1,0 +1,7 @@
+*** settings ***
+Library    KeywordLibrary
+
+
+*** test cases
+Test
+    Pass

--- a/tests/atest/transformers/ExternalTransformer/expected/tests_only_defaults.robot
+++ b/tests/atest/transformers/ExternalTransformer/expected/tests_only_defaults.robot
@@ -1,0 +1,7 @@
+*** Settings ***
+Library     KeywordLibrary
+
+
+*** Test Cases ***
+Test
+    Pass

--- a/tests/atest/transformers/ExternalTransformer/expected/tests_with_defaults.robot
+++ b/tests/atest/transformers/ExternalTransformer/expected/tests_with_defaults.robot
@@ -1,0 +1,9 @@
+*** Settings ***
+Library     KeywordLibrary
+
+
+
+
+*** Test Cases ***
+Test
+    Pass

--- a/tests/atest/transformers/ExternalTransformer/expected/tests_with_defaults_lowercase.robot
+++ b/tests/atest/transformers/ExternalTransformer/expected/tests_with_defaults_lowercase.robot
@@ -1,0 +1,7 @@
+*** settings ***
+Library     KeywordLibrary
+
+
+*** test cases ***
+Test
+    Pass

--- a/tests/atest/transformers/ExternalTransformer/test_transformer.py
+++ b/tests/atest/transformers/ExternalTransformer/test_transformer.py
@@ -1,19 +1,65 @@
 from pathlib import Path
 
+import pytest
+
 from .. import TransformerAcceptanceTest
+
+
+@pytest.fixture(scope="session")
+def transformer_relative_path():
+    cwd = Path.cwd()
+    transformer_abs_path = Path(Path(__file__).parent, "ExternalTransformer.py")
+    return transformer_abs_path.relative_to(cwd)
+
+
+@pytest.fixture(scope="session")
+def disabled_transformer_relative_path():
+    cwd = Path.cwd()
+    transformer_abs_path = Path(Path(__file__).parent, "ExternalDisabledTransformer.py")
+    return transformer_abs_path.relative_to(cwd)
+
+
+@pytest.fixture(scope="session")
+def transformer_absolute_path():
+    return Path(Path(__file__).parent, "ExternalTransformer.py")
+
+
+@pytest.fixture(scope="session")
+def disabled_transformer_absolute_path():
+    return Path(Path(__file__).parent, "ExternalDisabledTransformer.py")
 
 
 class TestExternalTransformer(TransformerAcceptanceTest):
     TRANSFORMER_NAME = "ExternalTransformer"
 
-    def test_external_transformer_absolute_path(self):
-        transformer_path = Path(Path(__file__).parent, "ExternalTransformer.py")
-        self.run_tidy(args=f"--transform {transformer_path}:param=2".split(), source="tests.robot")
+    def test_transform_absolute_path(self, transformer_absolute_path):
+        self.run_tidy(args=f"--transform {transformer_absolute_path}:param=2".split(), source="tests.robot")
         self.compare_file("tests.robot")
 
-    def test_external_transformer_relative_path(self):
-        cwd = Path.cwd()
-        transformer_abs_path = Path(Path(__file__).parent, "ExternalTransformer.py")
-        transformer_path = transformer_abs_path.relative_to(cwd)
-        self.run_tidy(args=f"--transform {transformer_path}:param=2".split(), source="tests.robot")
+    def test_transform_relative_path(self, transformer_relative_path):
+        self.run_tidy(args=f"--transform {transformer_relative_path}:param=2".split(), source="tests.robot")
         self.compare_file("tests.robot")
+
+    def test_load_absolute_path(self, transformer_absolute_path):
+        self.run_tidy(args=f"--load-transformers {transformer_absolute_path}:param=2".split(), source="tests.robot")
+        self.compare_file("tests.robot", expected_name="tests_with_defaults.robot")
+
+    def test_load_relative_path(self, transformer_relative_path):
+        self.run_tidy(args=f"--load-transformers {transformer_relative_path}:param=2".split(), source="tests.robot")
+        self.compare_file("tests.robot", expected_name="tests_with_defaults.robot")
+
+    def test_transform_disabled_absolute_path(self, disabled_transformer_absolute_path):
+        self.run_tidy(args=f"--transform {disabled_transformer_absolute_path}".split(), source="tests.robot")
+        self.compare_file("tests.robot", expected_name="tests_lowercase.robot")
+
+    def test_transform_disabled_relative_path(self, disabled_transformer_relative_path):
+        self.run_tidy(args=f"--transform {disabled_transformer_relative_path}".split(), source="tests.robot")
+        self.compare_file("tests.robot", expected_name="tests_lowercase.robot")
+
+    def test_load_disabled_absolute_path(self, disabled_transformer_absolute_path):
+        self.run_tidy(args=f"--load-transformers {disabled_transformer_absolute_path}".split(), source="tests.robot")
+        self.compare_file("tests.robot", expected_name="tests_only_defaults.robot")
+
+    def test_load_disabled_relative_path(self, disabled_transformer_relative_path):
+        self.run_tidy(args=f"--load-transformers {disabled_transformer_relative_path}".split(), source="tests.robot")
+        self.compare_file("tests.robot", expected_name="tests_only_defaults.robot")

--- a/tests/e2e/test_transform_stability.py
+++ b/tests/e2e/test_transform_stability.py
@@ -94,7 +94,7 @@ def get_enable_disabled_config() -> List[str]:
         return not getattr(transformer, "ENABLED", True)
 
     transformers = load_transformers(
-        None, {}, allow_disabled=True, target_version=ROBOT_VERSION.major, allow_version_mismatch=False
+        [], [], {}, allow_disabled=True, target_version=ROBOT_VERSION.major, allow_version_mismatch=False
     )
     config = []
     for transformer in transformers:

--- a/tests/utest/test_utils.py
+++ b/tests/utest/test_utils.py
@@ -24,6 +24,7 @@ def app():
     )
     config = Config(
         transformers=[],
+        custom_transformers=[],
         transformers_config=[],
         skip=skip_config,
         src=(".",),


### PR DESCRIPTION
It implements first part of #476 

New option is added: ``--load-transformers`` which loads custom transformers and runs them after default ones. Before the only option to load custom transformers was to use ``--transform`` which also disabled every other transformer.

The code for importing the transformers got bit ugly but I will refactor it in the seperate PRs - for now I just copied over existing code loading transformers and reused it for ``--load-transformers``. Refactor would change a lot more of the code, making this PR hard to read that's why it will be done separetly.