### PR TITLE
Allow spaces in transformer name or config

### DIFF
--- a/docs/releasenotes/4.0.0.rst
+++ b/docs/releasenotes/4.0.0.rst
@@ -190,3 +190,12 @@ This behaviour didn't improve the readability and now single too long values wil
 this using ``split_single_value`` parameter (default ``False``)::
 
     > robotidy -c SplitTooLongLine:split_single_value=True
+
+Spaces in the transformer name or configuration
+-------------------------------------------------
+
+Spaces are now allowed in the transformer path or configuration value. To provide such name or value
+enclose it with quotation marks::
+
+    > robotidy --load-transformer "C:\\My Transformers\\Transformer.py"
+    > robotidy --configure CustomTransformer:value="param value"

--- a/robotidy/transformers/__init__.py
+++ b/robotidy/transformers/__init__.py
@@ -66,7 +66,7 @@ IMPORTER = Importer()
 
 class TransformConfig:
     def __init__(self, config, force_include, custom_transformer, is_config):
-        name, args = split_args_from_name_or_path(config.replace(" ", ""))
+        name, args = split_args_from_name_or_path(config)
         self.name = name
         self.args = self.convert_args(args)
         self.force_include = force_include

--- a/tests/atest/transformers/ExternalTransformer/test_transformer.py
+++ b/tests/atest/transformers/ExternalTransformer/test_transformer.py
@@ -25,50 +25,50 @@ class TestExternalTransformer(TransformerAcceptanceTest):
 
     @pytest.mark.parametrize("external_transformer", [EXTERNAL_TRANSFORMER, EXTERNAL_TRANSFORMER_REL])
     def test_transform_external_transformer(self, external_transformer):
-        self.run_tidy(args=f"--transform {external_transformer}:param=2".split(), source="tests.robot")
+        self.run_tidy(args=["--transform", f"{external_transformer}:param=2"], source="tests.robot")
         self.compare_file("tests.robot")
 
     @pytest.mark.parametrize("external_transformer", [EXTERNAL_TRANSFORMER, EXTERNAL_TRANSFORMER_REL])
     def test_load_external_transformer(self, external_transformer):
-        self.run_tidy(args=f"--load-transformers {external_transformer}:param=2".split(), source="tests.robot")
+        self.run_tidy(args=["--load-transformers", f"{external_transformer}:param=2"], source="tests.robot")
         self.compare_file("tests.robot", expected_name="tests_with_defaults.robot")
 
     @pytest.mark.parametrize("disabled_transformer", [DISABLED_TRANSFORMER, DISABLED_TRANSFORMER_REL])
     def test_transform_disabled(self, disabled_transformer):
-        self.run_tidy(args=f"--transform {disabled_transformer}".split(), source="tests.robot")
+        self.run_tidy(args=["--transform", str(disabled_transformer)], source="tests.robot")
         self.compare_file("tests.robot", expected_name="tests_lowercase.robot")
 
     @pytest.mark.parametrize("disabled_transformer", [DISABLED_TRANSFORMER, DISABLED_TRANSFORMER_REL])
     def test_load_disabled(self, disabled_transformer):
-        self.run_tidy(args=f"--load-transformers {disabled_transformer}".split(), source="tests.robot")
+        self.run_tidy(args=["--load-transformers", str(disabled_transformer)], source="tests.robot")
         self.compare_file("tests.robot", expected_name="tests_only_defaults.robot")
 
     @pytest.mark.parametrize("module_path", [MODULE_TRANSFORMERS, MODULE_TRANSFORMERS_REL])
     def test_load_from_module(self, module_path):
-        self.run_tidy(args=f"--load-transformers {module_path}".split(), source="tests.robot")
+        self.run_tidy(args=["--load-transformers", str(module_path)], source="tests.robot")
         self.compare_file("tests.robot", expected_name="tests_module_load.robot")
 
     @pytest.mark.parametrize("module_path", [MODULE_TRANSFORMERS, MODULE_TRANSFORMERS_REL])
     def test_load_from_module(self, module_path):
-        self.run_tidy(args=f"--transform {module_path}".split(), source="tests.robot")
+        self.run_tidy(args=["--transform", str(module_path)], source="tests.robot")
         self.compare_file("tests.robot", expected_name="tests_module_transform.robot")
 
     @pytest.mark.parametrize("module_path", [MODULE_TRANSFORMERS, MODULE_TRANSFORMERS_REL])
     def test_load_from_module_and_configure(self, module_path):
-        cmd = f"--load-transformers {module_path} --configure CustomClass2:extra_param=True"
-        self.run_tidy(args=cmd.split(), source="tests.robot")
+        cmd = ["--load-transformers", str(module_path), "--configure", "CustomClass2:extra_param=True"]
+        self.run_tidy(args=cmd, source="tests.robot")
         self.compare_file("tests.robot", expected_name="tests_module_load_configure.robot")
 
     @pytest.mark.parametrize("module_path", [MODULE_TRANSFORMERS, MODULE_TRANSFORMERS_REL])
     def test_load_from_module_and_configure(self, module_path):
-        cmd = f"--transform {module_path} --configure CustomClass2:extra_param=True"
-        self.run_tidy(args=cmd.split(), source="tests.robot")
+        cmd = ["--transform", str(module_path), "--configure", "CustomClass2:extra_param=True"]
+        self.run_tidy(args=cmd, source="tests.robot")
         self.compare_file("tests.robot", expected_name="tests_module_transform_configure.robot")
 
     def test_transform_ordered(self):
-        self.run_tidy(f"--transform {MODULE_ORDERED_TRANFORMERS}".split(), source="tests.robot")
+        self.run_tidy(["--transform", str(MODULE_ORDERED_TRANFORMERS)], source="tests.robot")
         self.compare_file("tests.robot", expected_name="tests_module_transform.robot")
 
     def test_load_ordered(self):
-        self.run_tidy(f"--load-transformers {MODULE_ORDERED_TRANFORMERS}".split(), source="tests.robot")
+        self.run_tidy(["--load-transformers", str(MODULE_ORDERED_TRANFORMERS)], source="tests.robot")
         self.compare_file("tests.robot", expected_name="tests_module_load.robot")

--- a/tests/utest/test_load_transformers.py
+++ b/tests/utest/test_load_transformers.py
@@ -290,3 +290,17 @@ class TestLoadTransformers:
         )
         output = capsys.readouterr()
         assert output.out == expected_output
+
+    def test_space_in_param_value(self):
+        param_with_space = "Keyword With Space"
+        transformers = [
+            TransformConfig(
+                f"RenameKeywords:replace_to={param_with_space}",
+                force_include=True,
+                custom_transformer=False,
+                is_config=False,
+            )
+        ]
+        config_map = TransformConfigMap(transformers, [], [])
+        transformers = load_transformers(config_map, target_version=ROBOT_VERSION.major)
+        assert transformers[0].instance.replace_to == param_with_space


### PR DESCRIPTION
It's actually interesting because I only discovered this issue because I have cloned the tidy repository in the new directory with the space in the name - and external transformers tests started to fail (some of those tests generated absolute path to external transformer file and used it in robotidy config).

I used it as chance to improve upon so now it's also possible to use spaces in the param value too. We had to normalize spaces before with our old design but now it's not needed.