### PR TITLE
Add option to align new lines to previous line in SplitTooLongLine transformer

### DIFF
--- a/docs/releasenotes/4.0.0.rst
+++ b/docs/releasenotes/4.0.0.rst
@@ -226,6 +226,40 @@ this using ``split_single_value`` parameter (default ``False``)::
 
     > robotidy -c SplitTooLongLine:split_single_value=True
 
+SplitTooLongLine and aligning new line (#484)
+------------------------------------------------
+
+It is now possible to align new line to previous line when splitting too long line. This mode works only when we are
+filling the line until the line length limit (with one of the ``split_on_every_arg``, `split_on_every_value`` and
+``split_on_every_setting_arg`` flags). To enable it configure it using ``align_new_line``::
+
+    > robotidy -c SplitTooLongLine:align_new_line=True
+
+Following code::
+
+    *** Keywords ***
+    Keyword
+        [Tags]    longertagname1    longertagname2    longertagname3
+        Keyword With Longer Name    ${arg1}    ${arg2}    ${arg3}    # let's assume ${arg3} does not fit under limit
+
+with  ``align_new_line = False`` (default) is transformed to::
+
+    *** Keywords ***
+    Keyword
+        [Tags]    longertagname1    longertagname2
+        ...    longertagname3
+        Keyword With Longer Name    ${arg1}    ${arg2}
+        ...    ${arg3}
+
+and with ``align_new_line = True`` is transformed to::
+
+    *** Keywords ***
+    Keyword
+        [Tags]    longertagname1    longertagname2
+        ...       longertagname3
+        Keyword With Longer Name    ${arg1}    ${arg2}
+        ...                         ${arg3}
+
 Spaces in the transformer name or configuration
 -------------------------------------------------
 
@@ -234,3 +268,8 @@ enclose it with quotation marks::
 
     > robotidy --load-transformer "C:\\My Transformers\\Transformer.py"
     > robotidy --configure CustomTransformer:value="param value"
+
+Bugs
+-----
+
+- Fixed the bug where keyword name would be prefixed with continuation marks (``...``) if name was longer than line length limit (#494)

--- a/docs/releasenotes/4.0.0.rst
+++ b/docs/releasenotes/4.0.0.rst
@@ -230,7 +230,7 @@ SplitTooLongLine and aligning new line (#484)
 ------------------------------------------------
 
 It is now possible to align new line to previous line when splitting too long line. This mode works only when we are
-filling the line until the line length limit (with one of the ``split_on_every_arg``, `split_on_every_value`` and
+filling the line until the line length limit (with one of the ``split_on_every_arg``, ``split_on_every_value`` and
 ``split_on_every_setting_arg`` flags). To enable it configure it using ``align_new_line``::
 
     > robotidy -c SplitTooLongLine:align_new_line=True

--- a/docs/source/transformers/SplitTooLongLine.rst
+++ b/docs/source/transformers/SplitTooLongLine.rst
@@ -229,6 +229,48 @@ to split on single too long values using ``split_single_value`` option::
             ${SINGLE_HEADER}
             ...    veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery
 
+Align new line
+----------------
+
+It is possible to align new line to previous line when splitting too long line. This mode works only when we are
+filling the line until line the length limit (with one of the ``split_on_every_arg``, `split_on_every_value`` and
+``split_on_every_setting_arg`` flags). To enable it configure it using ``align_new_line``::
+
+    > robotidy -c SplitTooLongLine:align_new_line=True
+
+.. tab-set::
+
+    .. tab-item:: Before
+
+        .. code:: robotframework
+
+        *** Keywords ***
+        Keyword
+            [Tags]    longertagname1    longertagname2    longertagname3
+            Keyword With Longer Name    ${arg1}    ${arg2}    ${arg3}    # let's assume ${arg3} does not fit under limit
+
+    .. tab-item:: After (align_new_line = False)
+
+        .. code:: robotframework
+
+    *** Keywords ***
+    Keyword
+        [Tags]    longertagname1    longertagname2
+        ...    longertagname3
+        Keyword With Longer Name    ${arg1}    ${arg2}
+        ...    ${arg3}
+
+    .. tab-item:: After (align_new_line = True)
+
+        .. code:: robotframework
+
+    *** Keywords ***
+    Keyword
+        [Tags]    longertagname1    longertagname2
+        ...       longertagname3
+        Keyword With Longer Name    ${arg1}    ${arg2}
+        ...                         ${arg3}
+
 Ignore comments
 ----------------
 

--- a/docs/source/transformers/SplitTooLongLine.rst
+++ b/docs/source/transformers/SplitTooLongLine.rst
@@ -233,7 +233,7 @@ Align new line
 ----------------
 
 It is possible to align new line to previous line when splitting too long line. This mode works only when we are
-filling the line until line the length limit (with one of the ``split_on_every_arg``, `split_on_every_value`` and
+filling the line until line the length limit (with one of the ``split_on_every_arg``, ``split_on_every_value`` and
 ``split_on_every_setting_arg`` flags). To enable it configure it using ``align_new_line``::
 
     > robotidy -c SplitTooLongLine:align_new_line=True

--- a/tests/atest/transformers/SplitTooLongLine/expected/align_new_line.robot
+++ b/tests/atest/transformers/SplitTooLongLine/expected/align_new_line.robot
@@ -1,0 +1,31 @@
+*** Settings ***
+Force Tags    PS_CSMON_15838    PR_PPD    PR_B450
+...           PR_B650    PR_B850    PR_CS1000
+...           PR_CS1000L    PAR_ECG    PAR_IP_1
+...           PAR_SPO2
+
+
+*** Variables ***  # variables are not aligned but it will be handled by AlignVariablesSection
+@{LIST}
+...    valuevaluevaluevaluevalue
+...    valuevaluevaluevaluevalue
+...    valuevaluevaluevaluevalue
+
+
+*** Test Cases ***
+Testcase with a lot of tags
+    [Tags]    Tag1    Tag10    Tag11    Tag12
+    ...       Tag13    Tag2    Tag3    Tag4
+    ...       Tag5    Tag6    Tag7    Tag8    Tag9
+    ...       Tag14    Tag15
+    Fail
+
+
+*** Keywords ***
+Keyword
+    Keyword With Longer Name    ${arg1}    ${arg2}
+    ...                         ${arg3}
+
+Keyword Longer Than Limit
+    This Keyword Goes Beyond Limit And Next Argument Should Be In New Line
+    ...    ${arg}

--- a/tests/atest/transformers/SplitTooLongLine/source/align_new_line.robot
+++ b/tests/atest/transformers/SplitTooLongLine/source/align_new_line.robot
@@ -1,0 +1,20 @@
+*** Settings ***
+Force Tags    PS_CSMON_15838    PR_PPD    PR_B450    PR_B650    PR_B850    PR_CS1000    PR_CS1000L    PAR_ECG    PAR_IP_1    PAR_SPO2
+
+
+*** Variables ***  # variables are not aligned but it will be handled by AlignVariablesSection
+@{LIST}    valuevaluevaluevaluevalue    valuevaluevaluevaluevalue    valuevaluevaluevaluevalue
+
+
+*** Test Cases ***
+Testcase with a lot of tags
+    [Tags]    Tag1    Tag10    Tag11    Tag12    Tag13    Tag2    Tag3    Tag4    Tag5    Tag6    Tag7    Tag8    Tag9    Tag14    Tag15
+    Fail
+
+
+*** Keywords ***
+Keyword
+    Keyword With Longer Name    ${arg1}    ${arg2}    ${arg3}
+
+Keyword Longer Than Limit
+    This Keyword Goes Beyond Limit And Next Argument Should Be In New Line    ${arg}

--- a/tests/atest/transformers/SplitTooLongLine/test_transformer.py
+++ b/tests/atest/transformers/SplitTooLongLine/test_transformer.py
@@ -131,7 +131,6 @@ class TestSplitTooLongLine(TransformerAcceptanceTest):
             config=":split_on_every_setting_arg=False:skip_comments=True",
         )
 
-
     @pytest.mark.parametrize(
         "skip_config",
         [
@@ -154,4 +153,10 @@ class TestSplitTooLongLine(TransformerAcceptanceTest):
             source="variables.robot",
             expected="variables_split_scalar.robot",
             config=":split_single_value=True:line_length=80",
+        )
+
+    def test_align_new_lines(self):
+        self.compare(
+            source="align_new_line.robot",
+            config=":align_new_line=True:split_on_every_arg=False:split_on_every_setting_arg=False:line_length=51",
         )


### PR DESCRIPTION
Closes #484 
Fixes #494 