### PR TITLE
Rename variables

### DIFF
--- a/docs/releasenotes/4.0.0.rst
+++ b/docs/releasenotes/4.0.0.rst
@@ -21,7 +21,7 @@ or to install exactly this version::
 New transformer RenameVariables (#354)
 ---------------------------------------
 
-Transformer than renames and normalizes variable names.
+Transformer that renames and normalizes variable names.
 
 Following conventions are applied:
 

--- a/docs/releasenotes/4.0.0.rst
+++ b/docs/releasenotes/4.0.0.rst
@@ -5,7 +5,9 @@ Major release which contains multiple improvements for external transformers. Th
 changes, including removing ``section`` option from ``NormalizeSeparators`` (replaced with ``skip_sections``). We have
 also added following new transformers:
 
- - RemoveEmptyValues
+ - RenameVariables
+ - NormalizeComments
+ - ReplaceEmptyValues
  - GenerateDocumentation
 
 You can install the latest available version by running::
@@ -15,6 +17,152 @@ You can install the latest available version by running::
 or to install exactly this version::
 
     pip install robotframework-tidy==4.0.0
+
+New transformer RenameVariables (#354)
+---------------------------------------
+
+Transformer than renames and normalizes variable names.
+
+Following conventions are applied:
+
+- variable case depends on the variable scope (lowercase for local variables and uppercase for global variables)
+- leading and trailing whitespace is stripped
+- more than 2 consecutive whitespace in name is replaced by 1
+- whitespace is replaced by _
+- camelCase is converted to snake_case
+
+Conventions can be configured or switched off using parameters - read more in the documentation.
+
+Following code::
+
+    *** Settings ***
+    Suite Setup    ${keyword}
+
+    *** Variables ***
+    ${global}    String with {other global}
+
+    *** Test Cases ***
+    Test
+        ${local}    Set Variable    variable
+        Log    ${local}
+        Log    ${global}
+        Log    ${local['item']}
+
+    *** Keywords ***
+    Keyword
+        [Arguments]    ${ARG}
+        Log    ${arg}
+
+    Keyword With ${EMBEDDED}
+        Log    ${emb   eded}
+
+will be transformed to::
+
+    *** Settings ***
+    Suite Setup    ${KEYWORD}
+
+    *** Variables ***
+    ${GLOBAL}    String with {OTHER_GLOBAL}
+
+    *** Test Cases ***
+    Test
+        ${local}    Set Variable    variable
+        Log    ${local}
+        Log    ${GLOBAL}
+        Log    ${local['item']}
+
+    *** Keywords ***
+    Keyword
+        [Arguments]    ${arg}
+        Log    ${arg}
+
+    Keyword With ${embedded}
+        Log    ${emb_eded}
+
+New transformer ReplaceEmptyValues (#474)
+------------------------------------------
+
+This new, enabled by default transformer replaces empty values with ``${EMPTY}`` variable.
+
+Empty variables, lists or elements in the list can be defined in the following way::
+
+    *** Variables ***
+    ${EMPTY_VALUE}
+    @{EMPTY_LIST}
+    &{EMPTY_DICT}
+    @{LIST_WITH_EMPTY}
+    ...    value
+    ...
+    ...    value3
+
+To be more explicit, this transformer replace such values with ``${EMPTY}`` variables::
+
+    *** Variables ***
+    ${EMPTY_VALUE}    ${EMPTY}
+    @{EMPTY_LIST}     @{EMPTY}
+    &{EMPTY_DICT}     &{EMPTY}
+    @{LIST_WITH_EMPTY}
+    ...    value
+    ...    ${EMPTY}
+    ...    value3
+
+New transformer NormalizeComments (#290)
+-----------------------------------------
+
+``NormalizeComments`` handles comments formatting. For now, it only focuses on fixing ``missing-space-after-comment``
+rule violations from the Robocop::
+
+    *** Settings ***
+    #linecomment
+    ### header
+
+
+    *** Keywords ***
+    Keyword
+        Step  #comment
+
+will be transformed to::
+
+    *** Settings ***
+    # linecomment
+    ### header
+
+
+    *** Keywords ***
+    Keyword
+        Step  # comment
+    ```
+
+New transformer GenerateDocumentation (#311)
+--------------------------------------------
+
+Transformer that allows you to generate keyword documentation stubs based on the keyword data such as
+name, arguments or returned values. It uses Jinja templating internally and allows to define your own
+documentation templates. With default template (Google docstring) and following code::
+
+    *** Keywords ***
+    Keyword
+        [Arguments]    ${arg}
+        ${var}   ${var2}    Step
+        RETURN    ${var}    ${var2}
+
+it will generate::
+
+    *** Keywords ***
+    Keyword
+        [Documentation]
+        ...
+        ...    Arguments:
+        ...        ${arg}:
+        ...
+        ...    Returns:
+        ...        ${var}
+        ...        ${var2}
+        [Arguments]    ${arg}
+        ${var}   ${var2}    Step
+        RETURN    ${var}    ${var2}
+
+Read the transformer documentation for more details on configuring your own custom template.
 
 Rerun the transformation in place
 ----------------------------------
@@ -101,6 +249,7 @@ Currently supported in::
     NormalizeNewLines
     NormalizeSectionHeaderName
     NormalizeSeparators
+    RenameVariables
     ReplaceEmptyValues
     SplitTooLongLine
 
@@ -121,91 +270,6 @@ rather than the sections you want to format. For example following command::
 Is now equivalent of::
 
     > robotidy -c NormalizeSeparators:skip_sections=keywords
-
-New transformer ReplaceEmptyValues (#474)
-------------------------------------------
-
-This new, enabled by default transformer replaces empty values with ``${EMPTY}`` variable.
-
-Empty variables, lists or elements in the list can be defined in the following way::
-
-    *** Variables ***
-    ${EMPTY_VALUE}
-    @{EMPTY_LIST}
-    &{EMPTY_DICT}
-    @{LIST_WITH_EMPTY}
-    ...    value
-    ...
-    ...    value3
-
-To be more explicit, this transformer replace such values with ``${EMPTY}`` variables::
-
-    *** Variables ***
-    ${EMPTY_VALUE}    ${EMPTY}
-    @{EMPTY_LIST}     @{EMPTY}
-    &{EMPTY_DICT}     &{EMPTY}
-    @{LIST_WITH_EMPTY}
-    ...    value
-    ...    ${EMPTY}
-    ...    value3
-
-New transformer GenerateDocumentation (#311)
---------------------------------------------
-
-Transformer that allows you to generate keyword documentation stubs based on the keyword data such as
-name, arguments or returned values. It uses Jinja templating internally and allows to define your own
-documentation templates. With default template (Google docstring) and following code::
-
-    *** Keywords ***
-    Keyword
-        [Arguments]    ${arg}
-        ${var}   ${var2}    Step
-        RETURN    ${var}    ${var2}
-
-it will generate::
-
-    *** Keywords ***
-    Keyword
-        [Documentation]
-        ...
-        ...    Arguments:
-        ...        ${arg}:
-        ...
-        ...    Returns:
-        ...        ${var}
-        ...        ${var2}
-        [Arguments]    ${arg}
-        ${var}   ${var2}    Step
-        RETURN    ${var}    ${var2}
-
-Read the transformer documentation for more details on configuring your own custom template.
-
-New transformer NormalizeComments (#290)
------------------------------------------
-
-``NormalizeComments`` handles comments formatting. For now, it only focuses on fixing ``missing-space-after-comment``
-rule violations from the Robocop::
-
-    *** Settings ***
-    #linecomment
-    ### header
-
-
-    *** Keywords ***
-    Keyword
-        Step  #comment
-
-will be transformed to::
-
-    *** Settings ***
-    # linecomment
-    ### header
-
-
-    *** Keywords ***
-    Keyword
-        Step  # comment
-    ```
 
 Group comments with settings in OrderSettings (#468)
 ----------------------------------------------------

--- a/docs/releasenotes/4.0.0.rst
+++ b/docs/releasenotes/4.0.0.rst
@@ -25,7 +25,7 @@ Transformer that renames and normalizes variable names.
 
 Following conventions are applied:
 
-- variable case depends on the variable scope (lowercase for local variables and uppercase for global variables)
+- variable case depends on the variable scope (lowercase for local variables and uppercase for non-local variables)
 - leading and trailing whitespace is stripped
 - more than 2 consecutive whitespace in name is replaced by 1
 - whitespace is replaced by _

--- a/docs/source/transformers/RenameVariables.rst
+++ b/docs/source/transformers/RenameVariables.rst
@@ -1,0 +1,224 @@
+.. _RenameVariables:
+
+RenameVariables
+================
+Rename and normalize variable names.
+
+.. |TRANSFORMERNAME| replace:: RenameVariables
+.. include:: disabled_hint.txt
+
+Variable names in Settings, Variables, Test Cases and Keywords section are renamed. Variables in arguments are
+also affected.
+
+Following conventions are applied:
+
+- variable case depends on the variable scope (lowercase for local variables and uppercase for global variables)
+- leading and trailing whitespace is stripped
+- more than 2 consecutive whitespace in name is replaced by 1
+- whitespace is replaced by _
+- camelCase is converted to snake_case
+
+Conventions can be configured or switched off using parameters - read more in the following sections.
+
+.. tab-set::
+
+    .. tab-item:: Before
+
+        .. code:: robotframework
+
+            *** Settings ***
+            Suite Setup    ${keyword}
+
+            *** Variables ***
+            ${global}    String with {other global}
+
+            *** Test Cases ***
+            Test
+                ${local}    Set Variable    variable
+                Log    ${local}
+                Log    ${global}
+                Log    ${local['item']}
+
+            *** Keywords ***
+            Keyword
+                [Arguments]    ${ARG}
+                Log    ${arg}
+
+            Keyword With ${EMBEDDED}
+                Log    ${emb   eded}
+
+    .. tab-item:: After
+
+        .. code:: robotframework
+
+            *** Settings ***
+            Suite Setup    ${KEYWORD}
+
+            *** Variables ***
+            ${GLOBAL}    String with {OTHER_GLOBAL}
+
+            *** Test Cases ***
+            Test
+                ${local}    Set Variable    variable
+                Log    ${local}
+                Log    ${GLOBAL}
+                Log    ${local['item']}
+
+            *** Keywords ***
+            Keyword
+                [Arguments]    ${arg}
+                Log    ${arg}
+
+            Keyword With ${embedded}
+                Log    ${emb_eded}
+
+.. note::
+
+    RenameVariables is still under development and is not considered feature complete. Following syntax is not yet supported:
+
+      - changing variable scope with ``Śet Test/Suite/Global Variable``
+      - variable evaluation with ``${variable * 2}`` (following will be replaced to ``${variable_*_2}``
+
+    Robotidy can be locally disabled with # robotidy: off if you want to ignore specific cases.
+
+Variable case in Settings section
+---------------------------------
+
+All variables in the the ``*** Settings ***`` section are formatted to be uppercase. This behaviour is configurable
+using ``settings_section_case``::
+
+    > robotidy -c RenameVariables:settings_section_case=upper src
+
+Allowed values are:
+
+- ``upper`` (default) to uppercase names
+- ``lower`` to lowercase names
+- ``ignore`` to leave existing case
+
+Variable case in Variables section
+----------------------------------
+
+All variables in the the ``*** Variables ***`` section are formatted to be uppercase. This behaviour is configurable
+using ``variables_section_case``::
+
+    > robotidy -c RenameVariables:variables_section_case=upper src
+
+Allowed values are:
+
+- ``upper`` (default) to uppercase names
+- ``lower`` to lowercase names
+- ``ignore`` to leave existing case
+
+Variable case in Keywords, Tasks and Test Cases sections
+--------------------------------------------------------
+
+Variable case in ``*** Keywords ***``, ``*** Tasks ***`` and ``*** Test Cases ***`` sections depends on the
+variable scope. Local variables are lowercase and global variables are uppercase. Any unknown variable (not defined
+in current keyword or test case) is considered as global. You can configure what happes with unknown variables using
+``unknown_variables_case``::
+
+    > robotidy -c RenameVariables:unknown_variables_case=upper src
+
+Allowed values are:
+
+- ``upper`` (default) to uppercase unknown names
+- ``lower`` to lowercase unknown names
+- ``ignore`` to leave existing case
+
+.. tab-set::
+
+    .. tab-item:: Before
+
+        .. code:: robotframework
+
+            *** Keywords ***
+            Keyword
+                [Arguments]    ${arg}  # ${arg} is known
+                ${local}    Set Variable    value  # since we set it, ${local} is also known
+                Keyword Call    ${arg}    ${local}    ${global}  # ${global} is unknown
+
+    .. tab-item:: After (unknown_variables_case = upper)
+
+        .. code:: robotframework
+
+            *** Keywords ***
+            Keyword
+                [Arguments]    ${arg}  # ${arg} is known
+                ${local}    Set Variable    value  # since we set it, ${local} is also known
+                Keyword Call    ${arg}    ${local}    ${GLOBAL}  # ${global} is unknown
+
+    .. tab-item:: After (unknown_variables_case = lower)
+
+        .. code:: robotframework
+
+            *** Keywords ***
+            Keyword
+                [Arguments]    ${arg}  # ${arg} is known
+                ${local}    Set Variable    value  # since we set it, ${local} is also known
+                Keyword Call    ${arg}    ${local}    ${global}  # ${global} is unknown
+
+    .. tab-item:: After (unknown_variables_case = ignore)
+
+        .. code:: robotframework
+
+            *** Keywords ***
+            Keyword
+                [Arguments]    ${arg}  # ${arg} is known
+                ${local}    Set Variable    value  # since we set it, ${local} is also known
+                Keyword Call    ${arg}    ${local}    ${global}  # ${global} is unknown
+
+Converting camelCase to snake_case
+----------------------------------
+
+Variable names written in camelCase are converted to snake_case. You can disable this behaviour by configuring
+``convert_camel_case`` to ``False``::
+
+    > robotidy -c RenameVariables:convert_camel_case=False
+
+.. tab-set::
+
+    .. tab-item:: Before
+
+        .. code:: robotframework
+
+            *** Variables ***
+            ${camelCase}    value
+
+            *** Keywords ***
+            Keyword
+                ${CamelCase_Name}    Set Variable    value
+                Keyword Call    ${CamelCase_Name}
+
+    .. tab-item:: After - default (convert_camel_case = True)
+
+        .. code:: robotframework
+
+            *** Variables ***
+            ${camel_case}    value
+
+            *** Keywords ***
+            Keyword
+                ${camel_case_name}    Set Variable    value
+                Keyword Call    ${camel_case_name}
+
+    .. tab-item:: After (convert_camel_case = False)
+
+        .. code:: robotframework
+
+            *** Variables ***
+            ${CAMELCASE}    value
+
+            *** Keywords ***
+            Keyword
+                ${camelcase_name}    Set Variable    value
+                Keyword Call    ${camelcase_name}
+
+Skip formatting
+----------------
+
+It is possible to use the following arguments to skip formatting of the code:
+
+- :ref:`skip sections`
+
+It is also possible to use disablers (:ref:`disablers`) but ``skip`` option
+makes it easier to skip all instances of given type of the code.

--- a/docs/source/transformers/RenameVariables.rst
+++ b/docs/source/transformers/RenameVariables.rst
@@ -12,7 +12,7 @@ also affected.
 
 Following conventions are applied:
 
-- variable case depends on the variable scope (lowercase for local variables and uppercase for global variables)
+- variable case depends on the variable scope (lowercase for local variables and uppercase for non-local variables)
 - leading and trailing whitespace is stripped
 - more than 2 consecutive whitespace in name is replaced by 1
 - whitespace is replaced by _

--- a/docs/source/transformers/RenameVariables.rst
+++ b/docs/source/transformers/RenameVariables.rst
@@ -76,7 +76,6 @@ Conventions can be configured or switched off using parameters - read more in th
 
     RenameVariables is still under development and is not considered feature complete. Following syntax is not yet supported:
 
-      - changing variable scope with ``Set Test/Suite/Global Variable``
       - variable evaluation with ``${variable * 2}`` (following will be replaced to ``${variable_*_2}``
 
     Robotidy can be locally disabled with # robotidy: off if you want to ignore specific cases.

--- a/docs/source/transformers/RenameVariables.rst
+++ b/docs/source/transformers/RenameVariables.rst
@@ -76,7 +76,7 @@ Conventions can be configured or switched off using parameters - read more in th
 
     RenameVariables is still under development and is not considered feature complete. Following syntax is not yet supported:
 
-      - changing variable scope with ``Śet Test/Suite/Global Variable``
+      - changing variable scope with ``Set Test/Suite/Global Variable``
       - variable evaluation with ``${variable * 2}`` (following will be replaced to ``${variable_*_2}``
 
     Robotidy can be locally disabled with # robotidy: off if you want to ignore specific cases.
@@ -212,6 +212,56 @@ Variable names written in camelCase are converted to snake_case. You can disable
             Keyword
                 ${camelcase_name}    Set Variable    value
                 Keyword Call    ${camelcase_name}
+
+Variable separator
+-------------------
+
+Separators inside variable name are converted to underscore (``_``). You can configure it using ``variable_separator``::
+
+    > robotidy -c RenameVariables:variable_separator=underscore
+
+Allowed values are:
+
+- ``underscore`` (default)
+- ``space``
+
+.. tab-set::
+
+    .. tab-item:: Before
+
+        .. code:: robotframework
+
+            *** Variables ***
+            ${camelCase}    value
+
+            *** Keywords ***
+            Keyword
+                ${variable_name}    Set Variable    value
+                Keyword Call    ${variable name}
+
+    .. tab-item:: After - default (variable_separator = underscore)
+
+        .. code:: robotframework
+
+            *** Variables ***
+            ${CAMEL_CASE}    value
+
+            *** Keywords ***
+            Keyword
+                ${variable_name}    Set Variable    value
+                Keyword Call    ${variable_name}
+
+    .. tab-item:: After (variable_separator = space)
+
+        .. code:: robotframework
+
+            *** Variables ***
+            ${CAMEL CASE}    value
+
+            *** Keywords ***
+            Keyword
+                ${variable name}    Set Variable    value
+                Keyword Call    ${variable name}
 
 Skip formatting
 ----------------

--- a/docs/source/transformers/RenameVariables.rst
+++ b/docs/source/transformers/RenameVariables.rst
@@ -74,16 +74,16 @@ Conventions can be configured or switched off using parameters - read more in th
 
 .. note::
 
-    RenameVariables is still under development and is not considered feature complete. Following syntax is not yet supported:
+    RenameVariables is still under development and is not considered a complete feature. The following syntax is not yet supported:
 
       - variable evaluation with ``${variable * 2}`` (following will be replaced to ``${variable_*_2}``
 
-    Robotidy can be locally disabled with # robotidy: off if you want to ignore specific cases.
+    Robotidy can be locally disabled with ``# robotidy: off`` if you want to ignore specific cases.
 
 Variable case in Settings section
 ---------------------------------
 
-All variables in the the ``*** Settings ***`` section are formatted to be uppercase. This behaviour is configurable
+All variables in the ``*** Settings ***`` section are formatted to uppercase. This behaviour is configurable
 using ``settings_section_case``::
 
     > robotidy -c RenameVariables:settings_section_case=upper src
@@ -97,7 +97,7 @@ Allowed values are:
 Variable case in Variables section
 ----------------------------------
 
-All variables in the the ``*** Variables ***`` section are formatted to be uppercase. This behaviour is configurable
+All variables in the ``*** Variables ***`` section are formatted to uppercase. This behaviour is configurable
 using ``variables_section_case``::
 
     > robotidy -c RenameVariables:variables_section_case=upper src

--- a/robotidy/transformers/RenameVariables.py
+++ b/robotidy/transformers/RenameVariables.py
@@ -160,7 +160,7 @@ class RenameVariables(Transformer):
                 f"Invalid case type. Allowed case types are: {case_types}",
             )
 
-    def validate_variable_separator(self, variable_separator):
+    def validate_variable_separator(self, variable_separator: str):
         if variable_separator not in ("underscore", "space"):
             raise InvalidParameterValueError(
                 self.__class__.__name__,
@@ -198,7 +198,7 @@ class RenameVariables(Transformer):
     ) = visit_TestTemplate = visit_TestTimeout = visit_VariablesImport = visit_ResourceImport = visit_LibraryImport
 
     @skip_if_disabled
-    def visit_Setup(self, node):
+    def visit_Setup(self, node):  # noqa
         for data_token in node.data_tokens[1:]:
             data_token.value = self.rename_value(data_token.value, variable_case="auto", is_var=False)
         return self.generic_visit(node)
@@ -243,7 +243,7 @@ class RenameVariables(Transformer):
         return self.generic_visit(node)
 
     @skip_if_disabled
-    def visit_KeywordName(self, node):
+    def visit_KeywordName(self, node):  # noqa
         for token in node.data_tokens:
             name = ""
             for name_token in token.tokenize_variables():

--- a/robotidy/transformers/RenameVariables.py
+++ b/robotidy/transformers/RenameVariables.py
@@ -312,7 +312,7 @@ class RenameVariables(Transformer):
                         # is_var=False because it can contain space ie ${var} =
                         variable = self.rename_value(variable, variable_case="lower", is_var=False)
                         # default value can contain other argument, so we need to auto-detect case
-                        default = self.rename_value(default, variable_case="auto", is_var=False)  # TODO detect case
+                        default = self.rename_value(default, variable_case="auto", is_var=False)
                         arg.value = f"{variable}={default}"
                     else:
                         self.variables_scope.add_local(arg.value)

--- a/robotidy/transformers/RenameVariables.py
+++ b/robotidy/transformers/RenameVariables.py
@@ -1,0 +1,392 @@
+import re
+from typing import List, Pattern, Tuple
+
+from robot.api.parsing import Arguments, Token
+from robot.errors import VariableError
+from robot.variables import VariableIterator
+from robot.variables.search import _search_variable
+
+from robotidy.disablers import skip_if_disabled, skip_section_if_disabled
+from robotidy.exceptions import InvalidParameterValueError
+from robotidy.skip import Skip
+from robotidy.transformers import Transformer
+
+
+class VariablesScope:
+    def __init__(self):
+        self._local = set()
+        self._global = set()
+
+    def normalize_name(self, variable: str):
+        """
+        Return normalized variable name. Normalized name is :
+
+         - lowercase
+         - underscored and spaces removed
+
+        """
+        return variable.lower().replace("_", "").replace(" ", "")
+
+    def add_global(self, variable: str):
+        match = _search_variable(variable, identifiers="$@&%*")
+        if not match.base:
+            return
+        self._global.add(self.normalize_name(match.base))
+
+    def add_local(self, variable: str, split_pattern: bool = False):
+        """Add variable name to local cache.
+
+        If the variable is embedded argument, it can contain pattern we need to ignore (${var:[^pattern]})
+        """
+        match = _search_variable(variable, identifiers="$@&%*")
+        if not match.base:
+            return
+        name = match.base
+        if split_pattern:
+            name = name.split(":", maxsplit=1)[0]
+        self._local.add(self.normalize_name(name))
+
+    def is_local(self, variable: str):
+        return self.normalize_name(variable) in self._local
+
+    def is_global(self, variable: str):
+        return self.normalize_name(variable) in self._global
+
+
+class RenameVariables(Transformer):
+    """
+    Rename and normalize variable names.
+
+    Variable names in Settings, Variables, Test Cases and Keywords section are renamed. Variables in arguments are
+    also affected.
+
+    Following conventions are applied:
+
+    - variable case depends on the variable scope (lowercase for local variables and uppercase for global variables)
+    - leading and trailing whitespace is stripped
+    - more than 2 consecutive whitespace in name is replaced by 1
+    - whitespace is replaced by _
+    - camelCase is converted to snake_case
+
+    Conventions can be configured or switched off using parameters - read more in the documentation.
+
+    Following code:
+
+    ```robotframework
+    *** Settings ***
+    Suite Setup    ${keyword}
+
+    *** Variables ***
+    ${global}    String with {other global}
+
+    *** Test Cases ***
+    Test
+        ${local}    Set Variable    variable
+        Log    ${local}
+        Log    ${global}
+        Log    ${local['item']}
+
+    *** Keywords ***
+    Keyword
+        [Arguments]    ${ARG}
+        Log    ${arg}
+
+    Keyword With ${EMBEDDED}
+        Log    ${emb   eded}
+
+    ```
+
+    will be transformed to:
+
+    ```robotframework
+    *** Settings ***
+    Suite Setup    ${KEYWORD}
+
+    *** Variables ***
+    ${GLOBAL}    String with {OTHER_GLOBAL}
+
+    *** Test Cases ***
+    Test
+        ${local}    Set Variable    variable
+        Log    ${local}
+        Log    ${GLOBAL}
+        Log    ${local['item']}
+
+    *** Keywords ***
+    Keyword
+        [Arguments]    ${arg}
+        Log    ${arg}
+
+    Keyword With ${embedded}
+        Log    ${emb_eded}
+
+    ```
+    """
+
+    ENABLED = False
+    HANDLES_SKIP = frozenset({"skip_sections"})
+    MORE_THAN_2_SPACES: Pattern = re.compile(r"\s{2,}")
+    CAMEL_CASE: Pattern = re.compile(r"((?<=[a-z0-9])[A-Z]|(?!^)[A-Z](?=[a-z]))")
+
+    def __init__(
+        self,
+        settings_section_case: str = "upper",
+        variables_section_case: str = "upper",
+        unknown_variables_case: str = "upper",
+        convert_camel_case: bool = True,
+        skip: Skip = None,
+    ):
+        super().__init__(skip)
+        self.validate_case("settings_section_case", settings_section_case, ["upper", "lower", "ignore"])
+        self.validate_case("variables_section_case", variables_section_case, ["upper", "lower", "ignore"])
+        self.validate_case("unknown_variables_case", unknown_variables_case, ["upper", "lower", "ignore"])
+        self.settings_section_case = settings_section_case
+        self.variables_section_case = variables_section_case
+        self.unknown_variables_case = unknown_variables_case
+        self.convert_camel_case = convert_camel_case
+        self.variables_scope = VariablesScope()
+
+    def validate_case(self, param_name: str, case: str, allowed_case: List):
+        if case not in allowed_case:
+            case_types = ", ".join(allowed_case)
+            raise InvalidParameterValueError(
+                self.__class__.__name__,
+                param_name,
+                case,
+                f"Invalid case type. Allowed case types are: {case_types}",
+            )
+
+    @skip_section_if_disabled
+    def visit_Section(self, node):  # noqa
+        return self.generic_visit(node)
+
+    @skip_if_disabled
+    def visit_LibraryImport(self, node):  # noqa
+        for data_token in node.data_tokens[1:]:
+            data_token.value = self.rename_value(
+                data_token.value, variable_case=self.settings_section_case, is_var=False
+            )
+        return self.generic_visit(node)
+
+    visit_DefaultTags = (
+        visit_TestTags
+    ) = (
+        visit_ForceTags
+    ) = (
+        visit_Metadata
+    ) = (
+        visit_SuiteSetup
+    ) = (
+        visit_SuiteTeardown
+    ) = (
+        visit_TestSetup
+    ) = (
+        visit_TestTeardown
+    ) = visit_TestTemplate = visit_TestTimeout = visit_VariablesImport = visit_ResourceImport = visit_LibraryImport
+
+    @skip_if_disabled
+    def visit_Setup(self, node):
+        for data_token in node.data_tokens[1:]:
+            data_token.value = self.rename_value(data_token.value, variable_case="auto", is_var=False)
+        return self.generic_visit(node)
+
+    visit_Teardown = visit_Timeout = visit_Template = visit_Setup
+
+    @skip_if_disabled
+    def visit_Variable(self, node):  # noqa
+        if node.errors:
+            return node
+        for data_token in node.data_tokens:
+            if data_token.type == Token.VARIABLE:
+                data_token.value = self.rename_value(
+                    data_token.value, variable_case=self.variables_section_case, is_var=True
+                )
+            elif data_token.type == Token.ARGUMENT:
+                data_token.value = self.rename_value(
+                    data_token.value, variable_case=self.variables_section_case, is_var=False
+                )
+        return node
+
+    @skip_if_disabled
+    def visit_TestCase(self, node):  # noqa
+        self.variables_scope = VariablesScope()
+        return self.generic_visit(node)
+
+    @skip_if_disabled
+    def visit_TemplateArguments(self, node):  # noqa
+        for arg_template in node.get_tokens(Token.ARGUMENT):
+            arg_template.value = self.rename_value(arg_template.value, variable_case="auto", is_var=False)
+        return self.generic_visit(node)  # noqa
+
+    @skip_if_disabled
+    def visit_TestCaseName(self, node):  # noqa
+        for token in node.data_tokens:
+            name = ""
+            for name_token in token.tokenize_variables():
+                if name_token.type == Token.VARIABLE:
+                    name_token.value = self.rename_value(name_token.value, variable_case="upper", is_var=True)
+                name += name_token.value
+            token.value = name
+        return self.generic_visit(node)
+
+    @skip_if_disabled
+    def visit_KeywordName(self, node):
+        for token in node.data_tokens:
+            name = ""
+            for name_token in token.tokenize_variables():
+                if name_token.type == Token.VARIABLE:
+                    self.variables_scope.add_local(name_token.value, split_pattern=True)
+                    name_token.value = self.rename_value(name_token.value, variable_case="lower", is_var=True)
+                name += name_token.value
+            token.value = name
+        return self.generic_visit(node)
+
+    @skip_if_disabled
+    def visit_Keyword(self, node):  # noqa
+        self.variables_scope = VariablesScope()
+        # we need to find arguments before visiting body
+        for statement in node.body:
+            if isinstance(statement, Arguments):
+                for arg in statement.get_tokens(Token.ARGUMENT):
+                    if "=" in arg.value:
+                        variable, default = arg.value.split("=", maxsplit=1)
+                        self.variables_scope.add_local(variable)
+                        # is_var=False because it can contain space ie ${var} =
+                        variable = self.rename_value(variable, variable_case="lower", is_var=False)
+                        # default value can contain other argument, so we need to auto-detect case
+                        default = self.rename_value(default, variable_case="auto", is_var=False)  # TODO detect case
+                        arg.value = f"{variable}={default}"
+                    else:
+                        self.variables_scope.add_local(arg.value)
+                        arg.value = self.rename_value(arg.value, variable_case="lower", is_var=True)
+        return self.generic_visit(node)
+
+    def visit_KeywordCall(self, node):  # noqa
+        if not self.disablers.is_node_disabled(node):
+            for token in node.data_tokens:
+                if token.type == Token.ASSIGN:
+                    token.value = self.rename_value(token.value, variable_case="lower", is_var=False)
+                elif token.type in (Token.ARGUMENT, Token.KEYWORD):
+                    token.value = self.rename_value(token.value, variable_case="auto", is_var=False)
+        # we need to add assign to local scope after iterating keyword call because of
+        # ${overwritten_scope}  Set Variable  ${OVERWRITTEN_SCOPE}  case
+        for assign_token in node.get_tokens(Token.ASSIGN):
+            self.variables_scope.add_local(assign_token.value)
+        return node
+
+    @skip_if_disabled
+    def visit_For(self, node):  # noqa
+        for token in node.header:
+            if token.type == Token.VARIABLE:
+                self.variables_scope.add_local(token.value)
+                token.value = self.rename_value(token.value, variable_case="lower", is_var=True)
+            elif token.type == Token.ARGUMENT:
+                token.value = self.rename_value(token.value, variable_case="auto", is_var=False)
+        return self.generic_visit(node)
+
+    @skip_if_disabled
+    def visit_Try(self, node):  # noqa
+        if node.variable is not None:
+            error_var = node.header.get_token(Token.VARIABLE)
+            if error_var is not None:
+                self.variables_scope.add_local(error_var.value)
+                error_var.value = self.rename_value(error_var.value, variable_case="lower", is_var=True)
+        return self.generic_visit(node)
+
+    @skip_if_disabled
+    def visit_If(self, node):  # noqa
+        if node.errors:
+            return node
+        for assign in node.header.get_tokens(Token.ASSIGN):
+            self.variables_scope.add_local(assign.value)
+            assign.value = self.rename_value(assign.value, variable_case="lower", is_var=False)
+        return self.generic_visit(node)
+
+    def rename_value(self, value: str, variable_case: str, is_var: bool = False):
+        try:
+            variables = list(VariableIterator(value))
+        except VariableError:  # for example ${variable which wasn't closed properly
+            variables = []
+        if not variables:
+            if is_var:
+                return self.rename(value, case=variable_case, strip_fn="strip")
+            return value
+        name = ""
+        remaining = ""
+        for before, variable, remaining in variables:
+            if before:
+                if is_var:
+                    name += self.rename(before, case=variable_case, strip_fn="lstrip")
+                else:
+                    name += before
+            # handle ${variable}[item][${syntax}]
+            match = _search_variable(variable, identifiers="$@&%*")
+            # inline eval will start and end with {}
+            if not (match.base.startswith("{") and match.base.endswith("}")):
+                base = self.rename_value(match.base, variable_case=variable_case, is_var=True)
+                base = f"{match.name[:2]}{base}}}"
+            else:
+                base = match.name
+            for item in match.items:
+                renamed_item = self.rename_value(item, variable_case=variable_case, is_var=False)
+                base += f"[{renamed_item}]"
+            name += base
+        if remaining:
+            if is_var:
+                name += self.rename(remaining, case=variable_case, strip_fn="rstrip")
+            else:
+                name += remaining
+        return name
+
+    def set_name_case(self, name: str, case: str):
+        if case == "upper":
+            return name.upper()
+        if case == "lower":
+            return name.lower()
+        if case == "auto":
+            if self.variables_scope.is_local(name):
+                return name.lower()
+            if self.variables_scope.is_global(name):
+                return name.upper()
+            return self.set_name_case(name, self.unknown_variables_case)
+        return name
+
+    def rename(self, variable_value: str, case: str, strip_fn: str = "strip"):
+        if not variable_value:
+            return variable_value
+        # split on variable attribute access like ${var['item']}, ${var.item}, ${var(method)}..
+        variable_name, item_access = split_string_on_delimiter(variable_value)
+        if self.convert_camel_case:
+            variable_name = self.CAMEL_CASE.sub(r" \1", variable_name)
+        variable_name = self.set_name_case(variable_name, case)
+        variable_name = variable_name.replace("_", " ")
+        variable_name = self.MORE_THAN_2_SPACES.sub(" ", variable_name)
+        # to handle cases like ${var_${variable}_} we need to only strip whitespace at start/end depending on the type
+        if strip_fn == "strip":
+            variable_name = variable_name.strip()
+        elif strip_fn == "lstrip":
+            variable_name = variable_name.lstrip()
+        elif strip_fn == "rstrip":
+            variable_name = variable_name.rstrip()
+        variable_name = variable_name.replace(" ", "_")
+        return variable_name + item_access
+
+
+def split_string_on_delimiter(string: str) -> Tuple[str, str]:
+    """
+    Split string on first occurrence of the delimiters.
+
+    Return string before and after split, retaining delimiter.
+
+    Following strings returns:
+
+        item -> 'item', ''
+        item.value -> 'item', '.value'
+        item['value'] -> 'item', '['value']
+
+    """
+    delimiters = {".", "[", "(", ":"}
+    for index, char in enumerate(string):
+        if char in delimiters:
+            return string[:index], string[index:]
+    return string, ""

--- a/robotidy/transformers/RenameVariables.py
+++ b/robotidy/transformers/RenameVariables.py
@@ -107,7 +107,7 @@ class RenameVariables(Transformer):
 
     Following conventions are applied:
 
-    - variable case depends on the variable scope (lowercase for local variables and uppercase for global variables)
+    - variable case depends on the variable scope (lowercase for local variables and uppercase for non-local variables)
     - leading and trailing whitespace is stripped
     - more than 2 consecutive whitespace in name is replaced by 1
     - whitespace is replaced by _

--- a/robotidy/transformers/RenameVariables.py
+++ b/robotidy/transformers/RenameVariables.py
@@ -51,21 +51,11 @@ class VariablesScope:
         self._local = set()
         self._global = set()
 
-    def normalize_name(self, variable: str):
-        """
-        Return normalized variable name. Normalized name is :
-
-         - lowercase
-         - underscored and spaces removed
-
-        """
-        return variable.lower().replace("_", "").replace(" ", "")
-
     def add_global(self, variable: str):
         match = search_variable(variable, ignore_errors=True)
         if not match.base:
             return
-        self._global.add(self.normalize_name(match.base))
+        self._global.add(normalize_name(match.base))
 
     def add_local(self, variable: str, split_pattern: bool = False):
         """Add variable name to local cache.
@@ -78,7 +68,7 @@ class VariablesScope:
         name = match.base
         if split_pattern:
             name = name.split(":", maxsplit=1)[0]
-        self._local.add(self.normalize_name(name))
+        self._local.add(normalize_name(name))
 
     def change_scope_from_local_to_global(self, variable: str):
         """
@@ -88,14 +78,14 @@ class VariablesScope:
         if not match.base:
             return
         name = match.base
-        self._local.discard(self.normalize_name(name))
-        self._global.add(self.normalize_name(match.base))
+        self._local.discard(normalize_name(name))
+        self._global.add(normalize_name(match.base))
 
     def is_local(self, variable: str):
-        return self.normalize_name(variable) in self._local
+        return normalize_name(variable) in self._local
 
     def is_global(self, variable: str):
-        return self.normalize_name(variable) in self._global
+        return normalize_name(variable) in self._global
 
 
 class RenameVariables(Transformer):

--- a/robotidy/transformers/RenameVariables.py
+++ b/robotidy/transformers/RenameVariables.py
@@ -203,7 +203,7 @@ class RenameVariables(Transformer):
             data_token.value = self.rename_value(data_token.value, variable_case="auto", is_var=False)
         return self.generic_visit(node)
 
-    visit_Teardown = visit_Timeout = visit_Template = visit_Setup
+    visit_Teardown = visit_Timeout = visit_Template = visit_Return = visit_ReturnStatement = visit_Setup
 
     @skip_if_disabled
     def visit_Variable(self, node):  # noqa

--- a/robotidy/transformers/RenameVariables.py
+++ b/robotidy/transformers/RenameVariables.py
@@ -4,26 +4,12 @@ from typing import List, Pattern, Tuple
 from robot.api.parsing import Arguments, Token
 from robot.errors import VariableError
 from robot.variables import VariableIterator
-
-try:  # only available starting RF 6.0
-    from robot.variables.search import _search_variable
-
-    VariableSearcher = None
-except ImportError:
-    _search_variable = None
-    from robot.variables.search import VariableSearcher
+from robot.variables.search import search_variable
 
 from robotidy.disablers import skip_if_disabled, skip_section_if_disabled
 from robotidy.exceptions import InvalidParameterValueError
 from robotidy.skip import Skip
 from robotidy.transformers import Transformer
-
-
-def search_variable(name: str, ignore_errors: bool):
-    identifiers = "$@&%*"
-    if _search_variable:
-        return _search_variable(name, identifiers, ignore_errors)
-    return VariableSearcher(identifiers, ignore_errors).search(name)
 
 
 class VariablesScope:

--- a/robotidy/transformers/__init__.py
+++ b/robotidy/transformers/__init__.py
@@ -41,6 +41,7 @@ TRANSFORMERS = [
     "OrderSettingsSection",
     "NormalizeTags",
     "OrderTags",
+    "RenameVariables",
     "IndentNestedKeywords",
     "AlignSettingsSection",
     "AlignVariablesSection",
@@ -60,7 +61,6 @@ TRANSFORMERS = [
     "InlineIf",
     "Translate",
     "NormalizeComments",
-    "RenameVariables",
 ]
 
 

--- a/robotidy/transformers/__init__.py
+++ b/robotidy/transformers/__init__.py
@@ -60,6 +60,7 @@ TRANSFORMERS = [
     "InlineIf",
     "Translate",
     "NormalizeComments",
+    "RenameVariables",
 ]
 
 

--- a/tests/atest/transformers/RenameVariables/expected/disablers.robot
+++ b/tests/atest/transformers/RenameVariables/expected/disablers.robot
@@ -1,0 +1,48 @@
+*** Variables ***
+${VARIABLE}    value_
+${VAR_IABLE}    ${VA_LUE}
+${VARIABLE}    This is string with ${VARIABLE}
+${${VAR}}    value
+${VARIABLE}    ${${VARIABLE}}
+${VARIABLE}    ${VAR_${VARIABLE}_VAR}
+${VARIABLE}    String with ${${variable}}  # robotidy: off
+${VARIABLE}    ${VARIABLE['item_access']}
+${VARIABLE}    ${VARIABLE}[item_access]
+${VARIABLE}    ${VARIABLE}[${ITEM}_access]
+${VARIABLE}    ${}____
+${VARI_ABLE}    ${WO_RD}
+${VARIABLE}     \${escaped}
+
+&{DICT}    item=value
+...    item=${VALUE}
+@{LIST}    value
+...    other ${VALUE}
+...    ${{embedd_ ed}
+
+${CAMEL_CASE_NAME}    ${CAMEL_CASE_NAME}
+${CAMEL_CASE_NAME}    ${CAMEL_CASE_NAME}
+${CAMEL_CASE_NAME}    ${CAMEL_CASE_NAME}
+${CAMEL_CASE_NAME_WORD_CAMEL_CASE}    ${CAMEL_CASE_NAME_WORD_CAMEL_CASE}
+
+
+*** Test Cases ***
+Assign
+    ${variable}    Keyword
+    ${multiple}
+    ...   ${variables}    Keyword
+    ${variable} =    Keyword
+    ${variable}=    Keyword
+
+Args
+    Keyword    ${VARIABLE}
+    Keyword    ${v a _riAbles}  # robotidy: off
+    ...    value with ${_ variable _}
+
+Arguments
+    [Arguments]    ${arg}   # TODO
+    Step
+
+# globals
+# embedded
+# FOR ${var}
+# settings

--- a/tests/atest/transformers/RenameVariables/expected/inline_if.robot
+++ b/tests/atest/transformers/RenameVariables/expected/inline_if.robot
@@ -1,0 +1,5 @@
+*** Keywords ***
+Keyword With Inline IF
+    Log    ${GLOBAL}
+    ${global}    IF    $condition    Keyword
+    Log    ${global}

--- a/tests/atest/transformers/RenameVariables/expected/return_and_set_global.robot
+++ b/tests/atest/transformers/RenameVariables/expected/return_and_set_global.robot
@@ -1,0 +1,8 @@
+*** Keywords ***
+[Return]
+    ${local}    Set Variable    value
+    [Return]    ${local}    ${GLOBAL}
+
+RETURN
+    ${local}    Set Variable    value
+    RETURN    ${local}    ${GLOBAL}

--- a/tests/atest/transformers/RenameVariables/expected/return_and_set_global.robot
+++ b/tests/atest/transformers/RenameVariables/expected/return_and_set_global.robot
@@ -6,3 +6,19 @@
 RETURN
     ${local}    Set Variable    value
     RETURN    ${local}    ${GLOBAL}
+
+Set Variable
+    ${local}    Set Variable    value
+    ${local2}    Set Variable    value
+    ${local3}    Set Variable    value
+    ${local4}    Set Variable    value
+    @{local_list}    Keyword
+    &{local_dict}    Keyword
+    Set Test Variable
+    Set Test Variable    ${LOCAL}
+    Set Task Variable    $LOCAL2
+    Set Suite Variable    \${LOCAL3}
+    Set Global Variable    @{LOCAL_LIST}    value    ${GLOBAL_VALUE}
+    Set Global Variable    &LOCAL_DICT
+    Set Global Variable    ${LOCAL_${local4}}
+    Log Many    ${LOCAL}    ${LOCAL2}    ${LOCAL3}    ${local4}    @{LOCAL_LIST}    ${LOCAL_DICT}

--- a/tests/atest/transformers/RenameVariables/expected/test.robot
+++ b/tests/atest/transformers/RenameVariables/expected/test.robot
@@ -1,0 +1,115 @@
+*** Settings ***
+Library    ExampleLibrary    @{LIB_ARGS}
+Library    ${LIBRARY}    @{LIB_ARGS}
+
+Variables    ${NAME}.py
+Resource    ${CURDIR}/${NAME}.robot
+
+Suite Setup    Some Keyword    @{KW_ARGS}
+Suite Teardown    ${KEYWORD}    @{KW_ARGS}
+Test Setup    Some Keyword    @{KW_ARGS}
+Test Teardown    ${KEYWORD}    @{KW_ARGS}
+
+Default Tags    @{TAGS}    tag_${NAME}
+Test Timeout    ${TIMEOUT}
+
+Metadata  ${ITEM}    ${VALUE}
+
+
+*** Variables ***
+${VARIABLE}    value_
+${VAR_IABLE}    ${VA_LUE}
+${VARIABLE}    This is string with ${VARIABLE}
+${${VAR}}    value
+${VARIABLE}    ${${VARIABLE}}
+${VARIABLE}    ${VAR_${VARIABLE}_VAR}
+${VARIABLE}    String with ${${VARIABLE}}
+${VARIABLE}    ${VARIABLE['item_access']}
+${VARIABLE}    ${VARIABLE}[item_access]
+${VARIABLE}    ${VARIABLE}[${ITEM}_access]
+${VARIABLE}    ${VARIABLE['${VARIABLE}']}
+${VARIABLE}    ${}____
+${VARI_ABLE}    ${WO_RD}
+${VARIABLE}     \${escaped}
+${INLINE_EVAL}    ${{ eval }}
+
+&{DICT}    item=value
+...    item=${VALUE}
+@{LIST}    value
+...    other ${VALUE}
+...    ${{embedd_ ed}
+
+${CAMEL_CASE_NAME}    ${CAMEL_CASE_NAME}
+${CAMEL_CASE_NAME}    ${CAMEL_CASE_NAME}
+${CAMEL_CASE_NAME}    ${CAMEL_CASE_NAME}
+${CAMEL_CASE_NAME_WORD_CAMEL_CASE}    ${CAMEL_CASE_NAME_WORD_CAMEL_CASE}
+
+
+*** Test Cases ***
+Assign
+    ${variable}    Keyword
+    ${multiple}
+    ...   ${variables}    Keyword
+    ${variable} =    Keyword
+    ${variable}=    Keyword
+    Keyword  ${NESTED_${variable}}
+
+Args
+    Keyword    ${VARIABLE}
+    Keyword    ${V_A_RI_ABLES}
+    ...    value with ${VARIABLE}
+
+For header
+    ${local}    Set Variable    item
+    FOR    ${item}    IN    @{LIST}
+        Log    ${item}
+        Do Stuff    String with ${local} value
+        ...    ${lo_cal}  # TODO We could normalize it to look as first local matching variable
+    END
+    Log    ${GLOBAL}
+    Log    ${item}
+    FOR    ${index}    ${item}    IN ENUMERATE    @{LIST}
+         Log    ${index}    ${item}
+    END
+    Log    ${local['item']}
+    Log    ${GLOBAL['item']}
+
+Test With Variables In Keyword Call
+    [Setup]    ${KEYWORD}
+    ${local}    Set Variable    local value
+    Keyword Call With ${VARIABLE}
+    Keyword Call With ${local}
+    ${global}    Keyword Call With ${GLOBAL}
+    [Teardown]    ${local}
+
+Test case with ${VARIABLE} in name
+    [Documentation]    The RF surprises me vol. 678
+    Step
+
+
+*** Keywords ***
+Arguments
+    [Arguments]    ${arg}    ${arg2}
+    Step    ${arg}
+    Step    ${ARG3}
+
+Kwargs
+    [Arguments]    ${arg}    &{kwargs}
+    Step
+
+Defaults
+    [Arguments]    ${arg}    ${arg2} = 'default'
+    Step
+
+Defaults With Global
+    [Arguments]    ${arg}    ${arg2} =${GLOBAL}
+    Step
+
+Defaults With Other Arg
+    [Arguments]    ${arg}    ${arg2} = ${arg}
+    Step
+
+Embedded ${arguments} that ${should_be_lower} and also ${pattern:\S}
+    Log    ${should_be_lower}
+    Log    ${GLOBAL}
+    Log    ${pattern}

--- a/tests/atest/transformers/RenameVariables/expected/test_ignore_camel_case.robot
+++ b/tests/atest/transformers/RenameVariables/expected/test_ignore_camel_case.robot
@@ -1,0 +1,115 @@
+*** Settings ***
+Library    ExampleLibrary    @{LIB_ARGS}
+Library    ${LIBRARY}    @{LIB_ARGS}
+
+Variables    ${NAME}.py
+Resource    ${CURDIR}/${NAME}.robot
+
+Suite Setup    Some Keyword    @{KW_ARGS}
+Suite Teardown    ${KEYWORD}    @{KW_ARGS}
+Test Setup    Some Keyword    @{KW_ARGS}
+Test Teardown    ${KEYWORD}    @{KW_ARGS}
+
+Default Tags    @{TAGS}    tag_${NAME}
+Test Timeout    ${TIMEOUT}
+
+Metadata  ${ITEM}    ${VALUE}
+
+
+*** Variables ***
+${VARIABLE}    value_
+${VAR_IABLE}    ${VA_LUE}
+${VARIABLE}    This is string with ${VARIABLE}
+${${VAR}}    value
+${VARIABLE}    ${${VARIABLE}}
+${VARIABLE}    ${VAR_${VARIABLE}_VAR}
+${VARIABLE}    String with ${${VARIABLE}}
+${VARIABLE}    ${VARIABLE['item_access']}
+${VARIABLE}    ${VARIABLE}[item_access]
+${VARIABLE}    ${VARIABLE}[${ITEM}_access]
+${VARIABLE}    ${VARIABLE['${VARIABLE}']}
+${VARIABLE}    ${}____
+${VARI_ABLE}    ${WO_RD}
+${VARIABLE}     \${escaped}
+${INLINE_EVAL}    ${{ eval }}
+
+&{DICT}    item=value
+...    item=${VALUE}
+@{LIST}    value
+...    other ${VALUE}
+...    ${{embedd_ ed}
+
+${CAMELCASENAME}    ${CAMELCASENAME}
+${CAMELCASENAME}    ${CAMELCASENAME}
+${CAMELCASENAME}    ${CAMELCASENAME}
+${CAMELCASENAME_WORD_CAMELCASE}    ${CAMELCASENAME_WORD_CAMELCASE}
+
+
+*** Test Cases ***
+Assign
+    ${variable}    Keyword
+    ${multiple}
+    ...   ${variables}    Keyword
+    ${variable} =    Keyword
+    ${variable}=    Keyword
+    Keyword  ${NESTED_${variable}}
+
+Args
+    Keyword    ${VARIABLE}
+    Keyword    ${V_A_RIABLES}
+    ...    value with ${VARIABLE}
+
+For header
+    ${local}    Set Variable    item
+    FOR    ${item}    IN    @{LIST}
+        Log    ${item}
+        Do Stuff    String with ${local} value
+        ...    ${lo_cal}  # TODO We could normalize it to look as first local matching variable
+    END
+    Log    ${GLOBAL}
+    Log    ${item}
+    FOR    ${index}    ${item}    IN ENUMERATE    @{LIST}
+         Log    ${index}    ${item}
+    END
+    Log    ${local['item']}
+    Log    ${GLOBAL['item']}
+
+Test With Variables In Keyword Call
+    [Setup]    ${KEYWORD}
+    ${local}    Set Variable    local value
+    Keyword Call With ${VARIABLE}
+    Keyword Call With ${local}
+    ${global}    Keyword Call With ${GLOBAL}
+    [Teardown]    ${local}
+
+Test case with ${VARIABLE} in name
+    [Documentation]    The RF surprises me vol. 678
+    Step
+
+
+*** Keywords ***
+Arguments
+    [Arguments]    ${arg}    ${arg2}
+    Step    ${arg}
+    Step    ${ARG3}
+
+Kwargs
+    [Arguments]    ${arg}    &{kwargs}
+    Step
+
+Defaults
+    [Arguments]    ${arg}    ${arg2} = 'default'
+    Step
+
+Defaults With Global
+    [Arguments]    ${arg}    ${arg2} =${GLOBAL}
+    Step
+
+Defaults With Other Arg
+    [Arguments]    ${arg}    ${arg2} = ${arg}
+    Step
+
+Embedded ${arguments} that ${should_be_lower} and also ${pattern:\S}
+    Log    ${should_be_lower}
+    Log    ${GLOBAL}
+    Log    ${pattern}

--- a/tests/atest/transformers/RenameVariables/expected/test_ignore_settings_case.robot
+++ b/tests/atest/transformers/RenameVariables/expected/test_ignore_settings_case.robot
@@ -1,0 +1,115 @@
+*** Settings ***
+Library    ExampleLibrary    @{lib_args}
+Library    ${library}    @{lib_args}
+
+Variables    ${name}.py
+Resource    ${curdir}/${name}.robot
+
+Suite Setup    Some Keyword    @{kw_ARGS}
+Suite Teardown    ${Keyword}    @{KW_ARGS}
+Test Setup    Some Keyword    @{kw_ARGS}
+Test Teardown    ${Keyword}    @{KW_ARGS}
+
+Default Tags    @{tags}    tag_${name}
+Test Timeout    ${timeout}
+
+Metadata  ${item}    ${value}
+
+
+*** Variables ***
+${VARIABLE}    value_
+${VAR_IABLE}    ${VA_LUE}
+${VARIABLE}    This is string with ${VARIABLE}
+${${VAR}}    value
+${VARIABLE}    ${${VARIABLE}}
+${VARIABLE}    ${VAR_${VARIABLE}_VAR}
+${VARIABLE}    String with ${${VARIABLE}}
+${VARIABLE}    ${VARIABLE['item_access']}
+${VARIABLE}    ${VARIABLE}[item_access]
+${VARIABLE}    ${VARIABLE}[${ITEM}_access]
+${VARIABLE}    ${VARIABLE['${VARIABLE}']}
+${VARIABLE}    ${}____
+${VARI_ABLE}    ${WO_RD}
+${VARIABLE}     \${escaped}
+${INLINE_EVAL}    ${{ eval }}
+
+&{DICT}    item=value
+...    item=${VALUE}
+@{LIST}    value
+...    other ${VALUE}
+...    ${{embedd_ ed}
+
+${CAMEL_CASE_NAME}    ${CAMEL_CASE_NAME}
+${CAMEL_CASE_NAME}    ${CAMEL_CASE_NAME}
+${CAMEL_CASE_NAME}    ${CAMEL_CASE_NAME}
+${CAMEL_CASE_NAME_WORD_CAMEL_CASE}    ${CAMEL_CASE_NAME_WORD_CAMEL_CASE}
+
+
+*** Test Cases ***
+Assign
+    ${variable}    Keyword
+    ${multiple}
+    ...   ${variables}    Keyword
+    ${variable} =    Keyword
+    ${variable}=    Keyword
+    Keyword  ${NESTED_${variable}}
+
+Args
+    Keyword    ${VARIABLE}
+    Keyword    ${V_A_RI_ABLES}
+    ...    value with ${VARIABLE}
+
+For header
+    ${local}    Set Variable    item
+    FOR    ${item}    IN    @{LIST}
+        Log    ${item}
+        Do Stuff    String with ${local} value
+        ...    ${lo_cal}  # TODO We could normalize it to look as first local matching variable
+    END
+    Log    ${GLOBAL}
+    Log    ${item}
+    FOR    ${index}    ${item}    IN ENUMERATE    @{LIST}
+         Log    ${index}    ${item}
+    END
+    Log    ${local['item']}
+    Log    ${GLOBAL['item']}
+
+Test With Variables In Keyword Call
+    [Setup]    ${KEYWORD}
+    ${local}    Set Variable    local value
+    Keyword Call With ${VARIABLE}
+    Keyword Call With ${local}
+    ${global}    Keyword Call With ${GLOBAL}
+    [Teardown]    ${local}
+
+Test case with ${VARIABLE} in name
+    [Documentation]    The RF surprises me vol. 678
+    Step
+
+
+*** Keywords ***
+Arguments
+    [Arguments]    ${arg}    ${arg2}
+    Step    ${arg}
+    Step    ${ARG3}
+
+Kwargs
+    [Arguments]    ${arg}    &{kwargs}
+    Step
+
+Defaults
+    [Arguments]    ${arg}    ${arg2} = 'default'
+    Step
+
+Defaults With Global
+    [Arguments]    ${arg}    ${arg2} =${GLOBAL}
+    Step
+
+Defaults With Other Arg
+    [Arguments]    ${arg}    ${arg2} = ${arg}
+    Step
+
+Embedded ${arguments} that ${should_be_lower} and also ${pattern:\S}
+    Log    ${should_be_lower}
+    Log    ${GLOBAL}
+    Log    ${pattern}

--- a/tests/atest/transformers/RenameVariables/expected/test_ignore_unknown.robot
+++ b/tests/atest/transformers/RenameVariables/expected/test_ignore_unknown.robot
@@ -1,0 +1,115 @@
+*** Settings ***
+Library    ExampleLibrary    @{LIB_ARGS}
+Library    ${LIBRARY}    @{LIB_ARGS}
+
+Variables    ${NAME}.py
+Resource    ${CURDIR}/${NAME}.robot
+
+Suite Setup    Some Keyword    @{KW_ARGS}
+Suite Teardown    ${KEYWORD}    @{KW_ARGS}
+Test Setup    Some Keyword    @{KW_ARGS}
+Test Teardown    ${KEYWORD}    @{KW_ARGS}
+
+Default Tags    @{TAGS}    tag_${NAME}
+Test Timeout    ${TIMEOUT}
+
+Metadata  ${ITEM}    ${VALUE}
+
+
+*** Variables ***
+${VARIABLE}    value_
+${VAR_IABLE}    ${VA_LUE}
+${VARIABLE}    This is string with ${VARIABLE}
+${${VAR}}    value
+${VARIABLE}    ${${VARIABLE}}
+${VARIABLE}    ${VAR_${VARIABLE}_VAR}
+${VARIABLE}    String with ${${VARIABLE}}
+${VARIABLE}    ${VARIABLE['item_access']}
+${VARIABLE}    ${VARIABLE}[item_access]
+${VARIABLE}    ${VARIABLE}[${ITEM}_access]
+${VARIABLE}    ${VARIABLE['${VARIABLE}']}
+${VARIABLE}    ${}____
+${VARI_ABLE}    ${WO_RD}
+${VARIABLE}     \${escaped}
+${INLINE_EVAL}    ${{ eval }}
+
+&{DICT}    item=value
+...    item=${VALUE}
+@{LIST}    value
+...    other ${VALUE}
+...    ${{embedd_ ed}
+
+${CAMEL_CASE_NAME}    ${CAMEL_CASE_NAME}
+${CAMEL_CASE_NAME}    ${CAMEL_CASE_NAME}
+${CAMEL_CASE_NAME}    ${CAMEL_CASE_NAME}
+${CAMEL_CASE_NAME_WORD_CAMEL_CASE}    ${CAMEL_CASE_NAME_WORD_CAMEL_CASE}
+
+
+*** Test Cases ***
+Assign
+    ${variable}    Keyword
+    ${multiple}
+    ...   ${variables}    Keyword
+    ${variable} =    Keyword
+    ${variable}=    Keyword
+    Keyword  ${nested_${variable}}
+
+Args
+    Keyword    ${variable}
+    Keyword    ${v_a_ri_Ables}
+    ...    value with ${variable}
+
+For header
+    ${local}    Set Variable    item
+    FOR    ${item}    IN    @{list}
+        Log    ${item}
+        Do Stuff    String with ${local} value
+        ...    ${lo_cal}  # TODO We could normalize it to look as first local matching variable
+    END
+    Log    ${global}
+    Log    ${item}
+    FOR    ${index}    ${item}    IN ENUMERATE    @{LIST}
+         Log    ${index}    ${item}
+    END
+    Log    ${local['item']}
+    Log    ${global['item']}
+
+Test With Variables In Keyword Call
+    [Setup]    ${keyword}
+    ${local}    Set Variable    local value
+    Keyword Call With ${variable}
+    Keyword Call With ${local}
+    ${global}    Keyword Call With ${global}
+    [Teardown]    ${local}
+
+Test case with ${VARIABLE} in name
+    [Documentation]    The RF surprises me vol. 678
+    Step
+
+
+*** Keywords ***
+Arguments
+    [Arguments]    ${arg}    ${arg2}
+    Step    ${arg}
+    Step    ${arg3}
+
+Kwargs
+    [Arguments]    ${arg}    &{kwargs}
+    Step
+
+Defaults
+    [Arguments]    ${arg}    ${arg2} = 'default'
+    Step
+
+Defaults With Global
+    [Arguments]    ${arg}    ${arg2} =${global}
+    Step
+
+Defaults With Other Arg
+    [Arguments]    ${arg}    ${arg2} = ${arg}
+    Step
+
+Embedded ${arguments} that ${should_be_lower} and also ${pattern:\S}
+    Log    ${should_be_lower}
+    Log    ${global}
+    Log    ${pattern}

--- a/tests/atest/transformers/RenameVariables/expected/test_lower.robot
+++ b/tests/atest/transformers/RenameVariables/expected/test_lower.robot
@@ -1,0 +1,115 @@
+*** Settings ***
+Library    ExampleLibrary    @{lib_args}
+Library    ${library}    @{lib_args}
+
+Variables    ${name}.py
+Resource    ${curdir}/${name}.robot
+
+Suite Setup    Some Keyword    @{kw_args}
+Suite Teardown    ${keyword}    @{kw_args}
+Test Setup    Some Keyword    @{kw_args}
+Test Teardown    ${keyword}    @{kw_args}
+
+Default Tags    @{tags}    tag_${name}
+Test Timeout    ${timeout}
+
+Metadata  ${item}    ${value}
+
+
+*** Variables ***
+${variable}    value_
+${var_iable}    ${va_lue}
+${variable}    This is string with ${variable}
+${${VAR}}    value
+${variable}    ${${variable}}
+${variable}    ${var_${variable}_var}
+${variable}    String with ${${variable}}
+${variable}    ${variable['item_access']}
+${variable}    ${variable}[item_access]
+${variable}    ${variable}[${item}_access]
+${variable}    ${variable['${variable}']}
+${variable}    ${}____
+${vari_able}    ${wo_rd}
+${variable}     \${escaped}
+${inline_eval}    ${{ eval }}
+
+&{dict}    item=value
+...    item=${value}
+@{list}    value
+...    other ${value}
+...    ${{embedd_ ed}
+
+${camel_case_name}    ${camel_case_name}
+${camel_case_name}    ${camel_case_name}
+${camel_case_name}    ${camel_case_name}
+${camel_case_name_word_camel_case}    ${camel_case_name_word_camel_case}
+
+
+*** Test Cases ***
+Assign
+    ${variable}    Keyword
+    ${multiple}
+    ...   ${variables}    Keyword
+    ${variable} =    Keyword
+    ${variable}=    Keyword
+    Keyword  ${nested_${variable}}
+
+Args
+    Keyword    ${variable}
+    Keyword    ${v_a_ri_ables}
+    ...    value with ${variable}
+
+For header
+    ${local}    Set Variable    item
+    FOR    ${item}    IN    @{list}
+        Log    ${item}
+        Do Stuff    String with ${local} value
+        ...    ${lo_cal}  # TODO We could normalize it to look as first local matching variable
+    END
+    Log    ${global}
+    Log    ${item}
+    FOR    ${index}    ${item}    IN ENUMERATE    @{list}
+         Log    ${index}    ${item}
+    END
+    Log    ${local['item']}
+    Log    ${global['item']}
+
+Test With Variables In Keyword Call
+    [Setup]    ${keyword}
+    ${local}    Set Variable    local value
+    Keyword Call With ${variable}
+    Keyword Call With ${local}
+    ${global}    Keyword Call With ${global}
+    [Teardown]    ${local}
+
+Test case with ${VARIABLE} in name
+    [Documentation]    The RF surprises me vol. 678
+    Step
+
+
+*** Keywords ***
+Arguments
+    [Arguments]    ${arg}    ${arg2}
+    Step    ${arg}
+    Step    ${arg3}
+
+Kwargs
+    [Arguments]    ${arg}    &{kwargs}
+    Step
+
+Defaults
+    [Arguments]    ${arg}    ${arg2} = 'default'
+    Step
+
+Defaults With Global
+    [Arguments]    ${arg}    ${arg2} =${global}
+    Step
+
+Defaults With Other Arg
+    [Arguments]    ${arg}    ${arg2} = ${arg}
+    Step
+
+Embedded ${arguments} that ${should_be_lower} and also ${pattern:\S}
+    Log    ${should_be_lower}
+    Log    ${global}
+    Log    ${pattern}

--- a/tests/atest/transformers/RenameVariables/expected/test_separator_underscore.robot
+++ b/tests/atest/transformers/RenameVariables/expected/test_separator_underscore.robot
@@ -1,0 +1,115 @@
+*** Settings ***
+Library    ExampleLibrary    @{LIB ARGS}
+Library    ${LIBRARY}    @{LIB ARGS}
+
+Variables    ${NAME}.py
+Resource    ${CURDIR}/${NAME}.robot
+
+Suite Setup    Some Keyword    @{KW ARGS}
+Suite Teardown    ${KEYWORD}    @{KW ARGS}
+Test Setup    Some Keyword    @{KW ARGS}
+Test Teardown    ${KEYWORD}    @{KW ARGS}
+
+Default Tags    @{TAGS}    tag_${NAME}
+Test Timeout    ${TIMEOUT}
+
+Metadata  ${ITEM}    ${VALUE}
+
+
+*** Variables ***
+${VARIABLE}    value_
+${VAR IABLE}    ${VA LUE}
+${VARIABLE}    This is string with ${VARIABLE}
+${${VAR}}    value
+${VARIABLE}    ${${VARIABLE}}
+${VARIABLE}    ${VAR ${VARIABLE} VAR}
+${VARIABLE}    String with ${${VARIABLE}}
+${VARIABLE}    ${VARIABLE['item_access']}
+${VARIABLE}    ${VARIABLE}[item_access]
+${VARIABLE}    ${VARIABLE}[${ITEM}_access]
+${VARIABLE}    ${VARIABLE['${VARIABLE}']}
+${VARIABLE}    ${}____
+${VARI ABLE}    ${WO RD}
+${VARIABLE}     \${escaped}
+${INLINE EVAL}    ${{ eval }}
+
+&{DICT}    item=value
+...    item=${VALUE}
+@{LIST}    value
+...    other ${VALUE}
+...    ${{embedd_ ed}
+
+${CAMEL CASE NAME}    ${CAMEL CASE NAME}
+${CAMEL CASE NAME}    ${CAMEL CASE NAME}
+${CAMEL CASE NAME}    ${CAMEL CASE NAME}
+${CAMEL CASE NAME WORD CAMEL CASE}    ${CAMEL CASE NAME WORD CAMEL CASE}
+
+
+*** Test Cases ***
+Assign
+    ${variable}    Keyword
+    ${multiple}
+    ...   ${variables}    Keyword
+    ${variable} =    Keyword
+    ${variable}=    Keyword
+    Keyword  ${NESTED ${variable}}
+
+Args
+    Keyword    ${VARIABLE}
+    Keyword    ${V A RI ABLES}
+    ...    value with ${VARIABLE}
+
+For header
+    ${local}    Set Variable    item
+    FOR    ${item}    IN    @{LIST}
+        Log    ${item}
+        Do Stuff    String with ${local} value
+        ...    ${lo cal}  # TODO We could normalize it to look as first local matching variable
+    END
+    Log    ${GLOBAL}
+    Log    ${item}
+    FOR    ${index}    ${item}    IN ENUMERATE    @{LIST}
+         Log    ${index}    ${item}
+    END
+    Log    ${local['item']}
+    Log    ${GLOBAL['item']}
+
+Test With Variables In Keyword Call
+    [Setup]    ${KEYWORD}
+    ${local}    Set Variable    local value
+    Keyword Call With ${VARIABLE}
+    Keyword Call With ${local}
+    ${global}    Keyword Call With ${GLOBAL}
+    [Teardown]    ${local}
+
+Test case with ${VARIABLE} in name
+    [Documentation]    The RF surprises me vol. 678
+    Step
+
+
+*** Keywords ***
+Arguments
+    [Arguments]    ${arg}    ${arg2}
+    Step    ${arg}
+    Step    ${ARG3}
+
+Kwargs
+    [Arguments]    ${arg}    &{kwargs}
+    Step
+
+Defaults
+    [Arguments]    ${arg}    ${arg2} = 'default'
+    Step
+
+Defaults With Global
+    [Arguments]    ${arg}    ${arg2} =${GLOBAL}
+    Step
+
+Defaults With Other Arg
+    [Arguments]    ${arg}    ${arg2} = ${arg}
+    Step
+
+Embedded ${arguments} that ${should be lower} and also ${pattern:\S}
+    Log    ${should be lower}
+    Log    ${GLOBAL}
+    Log    ${pattern}

--- a/tests/atest/transformers/RenameVariables/expected/test_template.robot
+++ b/tests/atest/transformers/RenameVariables/expected/test_template.robot
@@ -1,0 +1,14 @@
+*** Settings ***
+Test Template    ${GLOBAL_KEYWORD_NAME}
+
+
+*** Test Cases ***
+Template with for loop
+    FOR    ${item}    IN    @{ITE_MS}
+        ${item}    2nd arg
+    END
+    FOR    ${index}    IN RANGE    42
+        1st arg    ${index}   ${GLOBAL}
+    END
+
+Test Name   ${ARG}    ${ARG2}

--- a/tests/atest/transformers/RenameVariables/expected/try_except.robot
+++ b/tests/atest/transformers/RenameVariables/expected/try_except.robot
@@ -1,0 +1,8 @@
+*** Keywords ***
+Keyword With Try
+     ${local} =    Keyword
+     TRY
+         Do Stuff    ${local}    ${GLOBAL}
+     EXCEPT    Error    AS    ${error}
+         Log    ${error}
+     END

--- a/tests/atest/transformers/RenameVariables/source/disablers.robot
+++ b/tests/atest/transformers/RenameVariables/source/disablers.robot
@@ -1,0 +1,48 @@
+*** Variables ***
+${variable_}    value_
+${var_iable_}    ${va lue}
+${VARIABLE}    This is string with ${variable}
+${${VAR}}    value
+${VARIABLE}    ${${variable}}
+${VARIABLE}    ${var_${variable}_var}
+${VARIABLE}    String with ${${variable}}  # robotidy: off
+${VARIABLE}    ${variable['item_access']}
+${VARIABLE}    ${variable}[item_access]
+${VARIABLE}    ${variable}[${item}_access]
+${VARIABLE__}    ${___}____
+${VARI_ ABLE}    ${wo_ rd}
+${VARIABLE}     \${escaped}
+
+&{dict}    item=value
+...    item=${value}
+@{list}    value
+...    other ${ value}
+...    ${{embedd_ ed}
+
+${camelCaseName}    ${camelCaseName}
+${CamelCaseName}    ${CamelCaseName}
+${camelCASEName}    ${camelCASEName}
+${camelCASEName_word_camelCase}    ${camelCASEName_WORD_camelCase}
+
+
+*** Test Cases ***
+Assign
+    ${ variable}    Keyword
+    ${MULTIPLE}
+    ...   ${variables }    Keyword
+    ${variable} =    Keyword
+    ${variable}=    Keyword
+
+Args
+    Keyword    ${variable }
+    Keyword    ${v a _riAbles}  # robotidy: off
+    ...    value with ${_ variable _}
+
+Arguments
+    [Arguments]    ${arg}   # TODO
+    Step
+
+# globals
+# embedded
+# FOR ${var}
+# settings

--- a/tests/atest/transformers/RenameVariables/source/inline_if.robot
+++ b/tests/atest/transformers/RenameVariables/source/inline_if.robot
@@ -1,0 +1,5 @@
+*** Keywords ***
+Keyword With Inline IF
+    Log    ${global}
+    ${GLOBAL}    IF    $condition    Keyword
+    Log    ${global}

--- a/tests/atest/transformers/RenameVariables/source/return_and_set_global.robot
+++ b/tests/atest/transformers/RenameVariables/source/return_and_set_global.robot
@@ -6,3 +6,19 @@
 RETURN
     ${local}    Set Variable    value
     RETURN    ${local}    ${global}
+
+Set Variable
+    ${local}    Set Variable    value
+    ${local2}    Set Variable    value
+    ${local3}    Set Variable    value
+    ${local4}    Set Variable    value
+    @{local_list}    Keyword
+    &{local_dict}    Keyword
+    Set Test Variable
+    Set Test Variable    ${local}
+    Set Task Variable    $local2
+    Set Suite Variable    \${local3}
+    Set Global Variable    @{local_list}    value    ${global_value}
+    Set Global Variable    &local_dict
+    Set Global Variable    ${local_${local4}}
+    Log Many    ${local}    ${local2}    ${local3}    ${local4}    @{local_list}    ${local_dict}

--- a/tests/atest/transformers/RenameVariables/source/return_and_set_global.robot
+++ b/tests/atest/transformers/RenameVariables/source/return_and_set_global.robot
@@ -1,0 +1,8 @@
+*** Keywords ***
+[Return]
+    ${local}    Set Variable    value
+    [Return]    ${local}    ${global}
+
+RETURN
+    ${local}    Set Variable    value
+    RETURN    ${local}    ${global}

--- a/tests/atest/transformers/RenameVariables/source/test.robot
+++ b/tests/atest/transformers/RenameVariables/source/test.robot
@@ -1,0 +1,115 @@
+*** Settings ***
+Library    ExampleLibrary    @{lib args}
+Library    ${library}    @{lib args}
+
+Variables    ${name}.py
+Resource    ${curdir}/${name}.robot
+
+Suite Setup    Some Keyword    @{kw ARGS}
+Suite Teardown    ${Keyword}    @{KW ARGS}
+Test Setup    Some Keyword    @{kw ARGS}
+Test Teardown    ${Keyword}    @{KW ARGS}
+
+Default Tags    @{tags}    tag_${name}
+Test Timeout    ${timeout}
+
+Metadata  ${item}    ${value}
+
+
+*** Variables ***
+${variable_}    value_
+${var_iable_}    ${va lue}
+${VARIABLE}    This is string with ${variable}
+${${VAR}}    value
+${VARIABLE}    ${${variable}}
+${VARIABLE}    ${var_${variable}_var}
+${VARIABLE}    String with ${${variable}}
+${VARIABLE}    ${variable['item_access']}
+${VARIABLE}    ${variable}[item_access]
+${VARIABLE}    ${variable}[${item}_access]
+${VARIABLE}    ${variable['${variable}']}
+${VARIABLE__}    ${___}____
+${VARI_ ABLE}    ${wo_ rd}
+${VARIABLE}     \${escaped}
+${INLINE_EVAL}    ${{ eval }}
+
+&{dict}    item=value
+...    item=${value}
+@{list}    value
+...    other ${ value}
+...    ${{embedd_ ed}
+
+${camelCaseName}    ${camelCaseName}
+${CamelCaseName}    ${CamelCaseName}
+${camelCASEName}    ${camelCASEName}
+${camelCASEName_word_camelCase}    ${camelCASEName_WORD_camelCase}
+
+
+*** Test Cases ***
+Assign
+    ${ variable}    Keyword
+    ${MULTIPLE}
+    ...   ${variables }    Keyword
+    ${variable} =    Keyword
+    ${variable}=    Keyword
+    Keyword  ${nested_${variable}}
+
+Args
+    Keyword    ${variable }
+    Keyword    ${v a _riAbles}
+    ...    value with ${_ variable _}
+
+For header
+    ${local}    Set Variable    item
+    FOR    ${ITEM}    IN    @{list}
+        Log    ${ITEM}
+        Do Stuff    String with ${LOCAL} value
+        ...    ${lo_CAL}  # TODO We could normalize it to look as first local matching variable
+    END
+    Log    ${global}
+    Log    ${ITEM}
+    FOR    ${INDEX}    ${ITEM}    IN ENUMERATE    @{LIST}
+         Log    ${INDEX}    ${ITEM}
+    END
+    Log    ${local['item']}
+    Log    ${global['item']}
+
+Test With Variables In Keyword Call
+    [Setup]    ${keyword}
+    ${local}    Set Variable    local value
+    Keyword Call With ${variable}
+    Keyword Call With ${local}
+    ${global}    Keyword Call With ${global}
+    [Teardown]    ${local}
+
+Test case with ${variable} in name
+    [Documentation]    The RF surprises me vol. 678
+    Step
+
+
+*** Keywords ***
+Arguments
+    [Arguments]    ${arg}    ${ARG2}
+    Step    ${arg}
+    Step    ${arg3}
+
+Kwargs
+    [Arguments]    ${arg}    &{KWARGS}
+    Step
+
+Defaults
+    [Arguments]    ${arg}    ${ARG2} = 'default'
+    Step
+
+Defaults With Global
+    [Arguments]    ${arg}    ${ARG2} =${global}
+    Step
+
+Defaults With Other Arg
+    [Arguments]    ${arg}    ${ARG2} = ${arg}
+    Step
+
+Embedded ${arguments} that ${SHOULD_BE_LOWER} and also ${pattern:\S}
+    Log    ${should_be lower}
+    Log    ${global}
+    Log    ${pattern}

--- a/tests/atest/transformers/RenameVariables/source/test_template.robot
+++ b/tests/atest/transformers/RenameVariables/source/test_template.robot
@@ -1,0 +1,14 @@
+*** Settings ***
+Test Template    ${global keyword name}
+
+
+*** Test Cases ***
+Template with for loop
+    FOR    ${item}    IN    @{ITEMs}
+        ${item}    2nd arg
+    END
+    FOR    ${index}    IN RANGE    42
+        1st arg    ${index}   ${global}
+    END
+
+Test Name   ${arg}    ${arg2}

--- a/tests/atest/transformers/RenameVariables/source/try_except.robot
+++ b/tests/atest/transformers/RenameVariables/source/try_except.robot
@@ -1,0 +1,8 @@
+*** Keywords ***
+Keyword With Try
+     ${local} =    Keyword
+     TRY
+         Do Stuff    ${local}    ${global}
+     EXCEPT    Error    AS    ${ERROR}
+         Log    ${ERROR}
+     END

--- a/tests/atest/transformers/RenameVariables/test_transformer.py
+++ b/tests/atest/transformers/RenameVariables/test_transformer.py
@@ -44,6 +44,9 @@ class TestRenameVariables(TransformerAcceptanceTest):
             source="test.robot", expected="test_separator_underscore.robot", config=":variable_separator=space"
         )
 
+    def test_return_and_set_globals(self):
+        self.compare(source="return_and_set_global.robot")
+
     @pytest.mark.parametrize(
         "param_name, allowed",
         [

--- a/tests/atest/transformers/RenameVariables/test_transformer.py
+++ b/tests/atest/transformers/RenameVariables/test_transformer.py
@@ -1,0 +1,60 @@
+import pytest
+
+from .. import TransformerAcceptanceTest
+
+
+class TestRenameVariables(TransformerAcceptanceTest):
+    TRANSFORMER_NAME = "RenameVariables"
+
+    def test_transformer(self):
+        self.compare(source="test.robot")
+
+    def test_template(self):
+        self.compare(source="test_template.robot")
+
+    def test_try_except(self):
+        self.compare(source="try_except.robot", target_version=">=5.0")
+
+    def test_inline_if(self):
+        self.compare(source="inline_if.robot", target_version=">=5.0")
+
+    def test_disablers(self):
+        self.compare(source="disablers.robot")
+
+    def test_lower_case(self):
+        self.compare(
+            source="test.robot",
+            expected="test_lower.robot",
+            config=":settings_section_case=lower:variables_section_case=lower:unknown_variables_case=lower",
+        )
+
+    def test_ignore_unknown_case(self):
+        self.compare(source="test.robot", expected="test_ignore_unknown.robot", config=":unknown_variables_case=ignore")
+
+    def test_ignore_settings_case(self):
+        self.compare(
+            source="test.robot", expected="test_ignore_settings_case.robot", config=":settings_section_case=ignore"
+        )
+
+    def test_ignore_camel_case(self):
+        self.compare(source="test.robot", expected="test_ignore_camel_case.robot", config=":convert_camel_case=False")
+
+    @pytest.mark.parametrize(
+        "param_name, allowed",
+        [
+            ("settings_section_case", "upper, lower, ignore"),
+            ("variables_section_case", "upper, lower, ignore"),
+            ("unknown_variables_case", "upper, lower, ignore"),
+        ],
+    )
+    def test_invalid_param(self, param_name, allowed):
+        result = self.run_tidy(
+            args=f"--transform {self.TRANSFORMER_NAME}:{param_name}=invalid".split(),
+            source="test.robot",
+            exit_code=1,
+        )
+        expected_output = (
+            f"Error: {self.TRANSFORMER_NAME}: Invalid '{param_name}' parameter value: 'invalid'. "
+            f"Invalid case type. Allowed case types are: {allowed}\n"
+        )
+        assert expected_output == result.output

--- a/tests/atest/transformers/RenameVariables/test_transformer.py
+++ b/tests/atest/transformers/RenameVariables/test_transformer.py
@@ -39,6 +39,11 @@ class TestRenameVariables(TransformerAcceptanceTest):
     def test_ignore_camel_case(self):
         self.compare(source="test.robot", expected="test_ignore_camel_case.robot", config=":convert_camel_case=False")
 
+    def test_separator_underscore(self):
+        self.compare(
+            source="test.robot", expected="test_separator_underscore.robot", config=":variable_separator=space"
+        )
+
     @pytest.mark.parametrize(
         "param_name, allowed",
         [
@@ -56,5 +61,17 @@ class TestRenameVariables(TransformerAcceptanceTest):
         expected_output = (
             f"Error: {self.TRANSFORMER_NAME}: Invalid '{param_name}' parameter value: 'invalid'. "
             f"Invalid case type. Allowed case types are: {allowed}\n"
+        )
+        assert expected_output == result.output
+
+    def test_invalid_variable_separator(self):
+        result = self.run_tidy(
+            args=f"--transform {self.TRANSFORMER_NAME}:variable_separator=invalid".split(),
+            source="test.robot",
+            exit_code=1,
+        )
+        expected_output = (
+            f"Error: {self.TRANSFORMER_NAME}: Invalid 'variable_separator' parameter value: 'invalid'. "
+            f"Allowed values are: underscore, space\n"
         )
         assert expected_output == result.output

--- a/tests/e2e/test_transform_stability.py
+++ b/tests/e2e/test_transform_stability.py
@@ -66,7 +66,11 @@ RERUN_NEEDED = {
     "Translate": {"pl_language_header": 2},
 }
 SKIP_TESTS_4 = {"ReplaceReturns": {"test"}, "GenerateDocumentation": {"test": 2}}
-SKIP_TESTS = {"ReplaceRunKeywordIf": {"invalid_data"}, "SplitTooLongLine": {"variables"}}
+SKIP_TESTS = {
+    "ReplaceRunKeywordIf": {"invalid_data"},
+    "SplitTooLongLine": {"variables"},
+    "AlignKeywordsSection": "error_node",
+}
 
 
 def run_tidy(cmd, enable_disabled: bool):


### PR DESCRIPTION
Closes #354 

Phew, I honestly can't believe I managed to complete it - it's fully working transformer that renames variables (and somehow doesn't trip on various Robot Framework syntax). There could be some edge cases still missing but I can cover them in the upcoming releases. 

This PR is last in current release - I will relase 4.0 after it.
