### PR TITLE
Release 4.0.1: Fix spaces in param:value

### DIFF
--- a/docs/releasenotes/4.0.1.rst
+++ b/docs/releasenotes/4.0.1.rst
@@ -1,0 +1,14 @@
+Robotidy 4.0.1
+================
+
+Fix release for breaking changes in the Robotidy 4.0. The spaces in param:value in ``pyproject.toml`` should not
+raise unrecognized parameter error anymore.
+
+You can install the latest available version by running::
+
+    pip install --upgrade robotframework-tidy
+
+or to install exactly this version::
+
+    pip install robotframework-tidy==4.0.1
+

--- a/robotidy/transformers/__init__.py
+++ b/robotidy/transformers/__init__.py
@@ -70,7 +70,7 @@ IMPORTER = Importer()
 class TransformConfig:
     def __init__(self, config, force_include, custom_transformer, is_config):
         name, args = split_args_from_name_or_path(config)
-        self.name = name
+        self.name = name.strip()
         self.args = self.convert_args(args)
         self.force_include = force_include
         self.custom_transformer = custom_transformer
@@ -85,6 +85,7 @@ class TransformConfig:
         for arg in args:
             try:
                 param, value = arg.split("=", maxsplit=1)
+                param, value = param.strip(), value.strip()
             except ValueError:
                 raise InvalidParameterFormatError(self.name) from None
             if param == "enabled":

--- a/tests/utest/test_cli.py
+++ b/tests/utest/test_cli.py
@@ -424,7 +424,7 @@ class TestCli:
             (".", ["test.robot", "test3.robot", "resources/test.robot"]),
         ],
     )
-    def test_src_in_configuration(self, source, should_parse, test_data_dir):
+    def test_src_and_space_in_param_in_configuration(self, source, should_parse, test_data_dir):
         source_dir = test_data_dir / "pyproject_with_src"
         os.chdir(source_dir)
         if source is not None:

--- a/tests/utest/testdata/pyproject_with_src/pyproject.toml
+++ b/tests/utest/testdata/pyproject_with_src/pyproject.toml
@@ -8,8 +8,9 @@ src = [
 startline = 10
 endline = 20
 transform = [
-   "DiscardEmptySections:allow_only_comments=True",
-   "SplitTooLongLine"
+    "DiscardEmptySections:allow_only_comments=True",
+    "OrderSettings",
+    "SplitTooLongLine"
 ]
 configure = [
     "DiscardEmptySections:allow_only_comments=False",


### PR DESCRIPTION
Fixes #504 

Recent improvement that allowed to use spaces in parameter value broke the feature where it was possible to configure transformer with spaces between parameters ("SomeTransformer : param value" in ``pyproject.toml``). This is important enough to be released as a separate fix.