### PR TITLE
Flatten multilines with NormalizeSeparators

### DIFF
--- a/docs/releasenotes/4.2.0.rst
+++ b/docs/releasenotes/4.2.0.rst
@@ -31,11 +31,11 @@ With following file structure::
 The ``test.robot`` file will use ``root/pyproject.toml`` configuration file and ``test2.robot`` will use
 ``root/source/nested/pyproject.toml``.
 
-Flatten multi line statements with NormalizeSeparators
+Flatten multiline statements with NormalizeSeparators
 -------------------------------------------------------
 
 New ``flatten_lines`` option in ``NormalizeSeparators`` transformer. By default ``NormalizeSeparators`` only updates
-the separators and leave any multi line intact. Now it is possible to flatten multi line statements into single line
+the separators and leave any multiline intact. Now it is possible to flatten multiline statements into single line
 using ``flatten_lines``::
 
     > robotidy -c NormalizeSeparators:flatten_lines=True src

--- a/docs/releasenotes/4.2.0.rst
+++ b/docs/releasenotes/4.2.0.rst
@@ -30,3 +30,12 @@ With following file structure::
 
 The ``test.robot`` file will use ``root/pyproject.toml`` configuration file and ``test2.robot`` will use
 ``root/source/nested/pyproject.toml``.
+
+Flatten multi line statements with NormalizeSeparators
+-------------------------------------------------------
+
+New ``flatten_lines`` option in ``NormalizeSeparators`` transformer. By default ``NormalizeSeparators`` only updates
+the separators and leave any multi line intact. Now it is possible to flatten multi line statements into single line
+using ``flatten_lines``::
+
+    > robotidy -c NormalizeSeparators:flatten_lines=True src

--- a/docs/source/transformers/NormalizeSeparators.rst
+++ b/docs/source/transformers/NormalizeSeparators.rst
@@ -138,6 +138,44 @@ Combine it with ``spacecount`` to set whitespace separately for indent and separ
                     Keyword With  ${var}
                 END
 
+Flatten multi line statements
+------------------------------
+
+By default ``NormalizeSeparators`` only updates the separators and leave any multi line intact. It is possible to
+flatten multi line statements into single line using ``flatten_lines`` option::
+
+    > robotidy -c NormalizeSeparators:flatten_lines=True src
+
+.. tab-set::
+
+    .. tab-item:: Before
+
+        .. code:: robotframework
+
+            *** Keywords ***
+            Keyword
+                Keyword Call    1  2
+                  ...    1  # comment
+                ...    2          3
+
+    .. tab-item:: After - default (flatten_lines = False)
+
+        .. code:: robotframework
+
+            *** Keywords ***
+            Keyword
+                Keyword Call    1    2
+                ...    1    # comment
+                ...    2    3
+
+    .. tab-item:: After (flatten_lines = True)
+
+        .. code:: robotframework
+
+            *** Keywords ***
+            Keyword
+                Keyword Call    1    2    1    2    3  # comment
+
 Skip formatting
 ----------------
 It is possible to use the following arguments to skip formatting of the code:
@@ -193,13 +231,6 @@ indentation, set ``skip_documentation`` to ``True``::
                 ...    a:               Argument A
                 ...    long_arg:        Argument long_arg.
                Test Case Body
-
-Skip formatting
-----------------
-
-It is possible to use the following arguments to skip formatting of the code:
-
-- :ref:`skip sections`
 
 It is also possible to use disablers (:ref:`disablers`) but ``skip`` option
 makes it easier to skip all instances of given type of the code.

--- a/robotidy/transformers/NormalizeSeparators.py
+++ b/robotidy/transformers/NormalizeSeparators.py
@@ -145,6 +145,8 @@ class NormalizeSeparators(Transformer):
                 prev_sep = False
             new_tokens.append(token)
             add_indent = False
+        if new_tokens and new_tokens[-1].type == Token.SEPARATOR:
+            new_tokens.pop()
         if comments:
             new_tokens.extend(join_comments(comments))
         if add_eol:

--- a/robotidy/transformers/aligners_core.py
+++ b/robotidy/transformers/aligners_core.py
@@ -13,7 +13,7 @@ from robotidy.disablers import skip_if_disabled
 from robotidy.exceptions import InvalidParameterValueError
 from robotidy.skip import Skip
 from robotidy.transformers import Transformer
-from robotidy.utils import is_blank_multiline, round_to_four
+from robotidy.utils import is_blank_multiline, join_comments, round_to_four
 
 WHITESPACE_TOKENS = frozenset({Token.SEPARATOR, Token.EOS})
 
@@ -472,15 +472,6 @@ def separate_comments(tokens):
         else:
             non_comments.append(token)
     return non_comments, comments
-
-
-def join_comments(comments):
-    tokens = []
-    separator = get_separator(2)
-    for token in comments:
-        tokens.append(separator)
-        tokens.append(token)
-    return tokens
 
 
 def align_fixed(tokens, sep_len, start_sep=False):

--- a/robotidy/utils.py
+++ b/robotidy/utils.py
@@ -439,11 +439,10 @@ def get_line_length_with_sep(tokens, sep_len: int):
     return get_line_length(tokens) + ((len(tokens) - 1) * sep_len)
 
 
-def join_comments(comments, prefix: bool = True) -> List:
+def join_comments(comments) -> List:
     tokens = []
     separator = Token(Token.SEPARATOR, "  ")
-    for index, token in enumerate(comments):
-        if index != 0 or prefix:
-            tokens.append(separator)
+    for token in comments:
+        tokens.append(separator)
         tokens.append(token)
     return tokens

--- a/robotidy/utils.py
+++ b/robotidy/utils.py
@@ -437,3 +437,13 @@ def get_line_length(tokens):
 
 def get_line_length_with_sep(tokens, sep_len: int):
     return get_line_length(tokens) + ((len(tokens) - 1) * sep_len)
+
+
+def join_comments(comments, prefix: bool = True) -> List:
+    tokens = []
+    separator = Token(Token.SEPARATOR, "  ")
+    for index, token in enumerate(comments):
+        if index != 0 or prefix:
+            tokens.append(separator)
+        tokens.append(token)
+    return tokens

--- a/tests/atest/transformers/NormalizeSeparators/expected/continuation_indent.robot
+++ b/tests/atest/transformers/NormalizeSeparators/expected/continuation_indent.robot
@@ -18,6 +18,6 @@ Keyword
     FOR  ${var}  IN  1  2
     ...    1  2
         Keyword Call  1  2
-        ...    1
+        ...    1  # comment
         ...    2  3
     END

--- a/tests/atest/transformers/NormalizeSeparators/expected/flatten.robot
+++ b/tests/atest/transformers/NormalizeSeparators/expected/flatten.robot
@@ -1,10 +1,9 @@
-  # this is   comment
+# this is    comment
 
 *** Settings ***
-Library  library.py  WITH NAME          alias
+Library    library.py    WITH NAME    alias
 
-Force Tags           tag
-...   tag
+Force Tags    tag    tag
 
 Documentation  doc
 ...      multi
@@ -14,60 +13,53 @@ Documentation  doc
 
 
 *** Variables ***
-${var}     3
- ${var2}  4
+${var}    3
+ ${var2}    4
 
 
 *** Test Cases ***
 Test case
-  [Setup]  Keyword
-  [Documentation]  First word   Second word
-   Keyword  with  arg
-   ...  and  multi  lines
-     [Teardown]          Keyword
+    [Setup]    Keyword
+    [Documentation]  First word   Second word
+    Keyword    with    arg    and    multi    lines
+    [Teardown]    Keyword
 
 Test case with structures
-    FOR  ${variable}  IN  1  2
-    Keyword
-     IF  ${condition}
-       Log  ${stuff}  console=True
-  END
-   END
+    FOR    ${variable}    IN    1    2
+        Keyword
+        IF    ${condition}
+            Log    ${stuff}    console=True
+        END
+    END
 
 *** Keywords ***
 Keyword
 Another Keyword
-          [Arguments]  ${arg}
-          [Documentation]  First word   Second word
-         ...  Third.
-       Should Be Equal  1
-       ...  ${arg}
-   IF  ${condition}
-        FOR  ${v}  IN RANGE  10
-   Keyword
+    [Arguments]    ${arg}
+    [Documentation]  First word   Second word
+    ...  Third.
+    Should Be Equal    1    ${arg}
+    IF    ${condition}
+        FOR    ${v}    IN RANGE    10
+            Keyword
         END
-   END
+    END
 
 Keyword With Tabulators
-    Keyword
-    ...  2
-	...  ${arg}
+    Keyword    2    ${arg}
 
 Nested IF 3
     [Documentation]    FAIL Inline IF cannot be nested.
-    IF                True    IF    True    Not run
+    IF    True    IF    True    Not run
     ...    ELSE IF    True    IF    True    Not run
     ...    ELSE               IF    True    Not run
 
 Keyword
-    [Arguments]    ${argument1}
-    ...    ${argument2}    ${argument3}
-    Keyword Call    1    2
-    ...    1
-    ...    2    3
-    FOR    ${var}    IN    1    2
-    ...    1    2
-        Keyword Call    1    2
-        ...    1  # comment
-        ...    2    3
+    [Arguments]    ${argument1}    ${argument2}    ${argument3}
+    Keyword Call    1    2    1    2    3
+    FOR    ${var}    IN    1    2    1    2
+        Keyword Call    1    2    1    2    3  # comment
     END
+
+Multiple Comments In Multiline Keyword
+    ${assign}    Keyword Call    ${arg}  # comment 1  # comment 2

--- a/tests/atest/transformers/NormalizeSeparators/expected/flatten.robot
+++ b/tests/atest/transformers/NormalizeSeparators/expected/flatten.robot
@@ -1,0 +1,73 @@
+  # this is   comment
+
+*** Settings ***
+Library  library.py  WITH NAME          alias
+
+Force Tags           tag
+...   tag
+
+Documentation  doc
+...      multi
+...  line
+
+# comment
+
+
+*** Variables ***
+${var}     3
+ ${var2}  4
+
+
+*** Test Cases ***
+Test case
+  [Setup]  Keyword
+  [Documentation]  First word   Second word
+   Keyword  with  arg
+   ...  and  multi  lines
+     [Teardown]          Keyword
+
+Test case with structures
+    FOR  ${variable}  IN  1  2
+    Keyword
+     IF  ${condition}
+       Log  ${stuff}  console=True
+  END
+   END
+
+*** Keywords ***
+Keyword
+Another Keyword
+          [Arguments]  ${arg}
+          [Documentation]  First word   Second word
+         ...  Third.
+       Should Be Equal  1
+       ...  ${arg}
+   IF  ${condition}
+        FOR  ${v}  IN RANGE  10
+   Keyword
+        END
+   END
+
+Keyword With Tabulators
+    Keyword
+    ...  2
+	...  ${arg}
+
+Nested IF 3
+    [Documentation]    FAIL Inline IF cannot be nested.
+    IF                True    IF    True    Not run
+    ...    ELSE IF    True    IF    True    Not run
+    ...    ELSE               IF    True    Not run
+
+Keyword
+    [Arguments]    ${argument1}
+    ...    ${argument2}    ${argument3}
+    Keyword Call    1    2
+    ...    1
+    ...    2    3
+    FOR    ${var}    IN    1    2
+    ...    1    2
+        Keyword Call    1    2
+        ...    1  # comment
+        ...    2    3
+    END

--- a/tests/atest/transformers/NormalizeSeparators/expected/flatten_rf4.robot
+++ b/tests/atest/transformers/NormalizeSeparators/expected/flatten_rf4.robot
@@ -1,0 +1,65 @@
+# this is    comment
+
+*** Settings ***
+Library    library.py    WITH NAME    alias
+
+Force Tags    tag    tag
+
+Documentation  doc
+...      multi
+...  line
+
+# comment
+
+
+*** Variables ***
+${var}    3
+ ${var2}    4
+
+
+*** Test Cases ***
+Test case
+    [Setup]    Keyword
+    [Documentation]  First word   Second word
+    Keyword    with    arg    and    multi    lines
+    [Teardown]    Keyword
+
+Test case with structures
+    FOR    ${variable}    IN    1    2
+        Keyword
+        IF    ${condition}
+            Log    ${stuff}    console=True
+        END
+    END
+
+*** Keywords ***
+Keyword
+Another Keyword
+    [Arguments]    ${arg}
+    [Documentation]  First word   Second word
+    ...  Third.
+    Should Be Equal    1    ${arg}
+    IF    ${condition}
+        FOR    ${v}    IN RANGE    10
+            Keyword
+        END
+    END
+
+Keyword With Tabulators
+    Keyword    2    ${arg}
+
+Nested IF 3
+    [Documentation]    FAIL Inline IF cannot be nested.
+    IF    True    IF    True    Not run
+    ...    ELSE IF    True    IF    True    Not run
+    ...    ELSE               IF    True    Not run
+
+Keyword
+    [Arguments]    ${argument1}    ${argument2}    ${argument3}
+    Keyword Call    1    2    1    2    3
+    FOR    ${var}    IN    1    2    1    2
+        Keyword Call    1    2    1    2    3  # comment
+    END
+
+Multiple Comments In Multiline Keyword
+    ${assign}    Keyword Call    ${arg}  # comment 1  # comment 2

--- a/tests/atest/transformers/NormalizeSeparators/expected/flatten_rf4.robot
+++ b/tests/atest/transformers/NormalizeSeparators/expected/flatten_rf4.robot
@@ -50,9 +50,7 @@ Keyword With Tabulators
 
 Nested IF 3
     [Documentation]    FAIL Inline IF cannot be nested.
-    IF    True    IF    True    Not run
-    ...    ELSE IF    True    IF    True    Not run
-    ...    ELSE               IF    True    Not run
+    IF    True    IF    True    Not run    ELSE IF    True    IF    True    Not run    ELSE    IF    True    Not run
 
 Keyword
     [Arguments]    ${argument1}    ${argument2}    ${argument3}

--- a/tests/atest/transformers/NormalizeSeparators/source/continuation_indent.robot
+++ b/tests/atest/transformers/NormalizeSeparators/source/continuation_indent.robot
@@ -18,6 +18,6 @@ Keyword
     FOR    ${var}    IN    1    2
     ...    1    2
         Keyword Call    1    2
-        ...    1
+        ...    1  # comment
         ...    2    3
     END

--- a/tests/atest/transformers/NormalizeSeparators/source/flatten.robot
+++ b/tests/atest/transformers/NormalizeSeparators/source/flatten.robot
@@ -71,3 +71,8 @@ Keyword
         ...    1  # comment
         ...    2    3
     END
+
+Multiple Comments In Multiline Keyword
+    ${assign}
+    ...    Keyword Call    # comment 1
+    ...    ${arg}    # comment 2

--- a/tests/atest/transformers/NormalizeSeparators/source/flatten.robot
+++ b/tests/atest/transformers/NormalizeSeparators/source/flatten.robot
@@ -1,0 +1,73 @@
+  # this is   comment
+
+*** Settings ***
+Library  library.py  WITH NAME          alias
+
+Force Tags           tag
+...   tag
+
+Documentation  doc
+...      multi
+...  line
+
+# comment
+
+
+*** Variables ***
+${var}     3
+ ${var2}  4
+
+
+*** Test Cases ***
+Test case
+  [Setup]  Keyword
+  [Documentation]  First word   Second word
+   Keyword  with  arg
+   ...  and  multi  lines
+     [Teardown]          Keyword
+
+Test case with structures
+    FOR  ${variable}  IN  1  2
+    Keyword
+     IF  ${condition}
+       Log  ${stuff}  console=True
+  END
+   END
+
+*** Keywords ***
+Keyword
+Another Keyword
+          [Arguments]  ${arg}
+          [Documentation]  First word   Second word
+         ...  Third.
+       Should Be Equal  1
+       ...  ${arg}
+   IF  ${condition}
+        FOR  ${v}  IN RANGE  10
+   Keyword
+        END
+   END
+
+Keyword With Tabulators
+    Keyword
+    ...  2
+	...  ${arg}
+
+Nested IF 3
+    [Documentation]    FAIL Inline IF cannot be nested.
+    IF                True    IF    True    Not run
+    ...    ELSE IF    True    IF    True    Not run
+    ...    ELSE               IF    True    Not run
+
+Keyword
+    [Arguments]    ${argument1}
+    ...    ${argument2}    ${argument3}
+    Keyword Call    1    2
+    ...    1
+    ...    2    3
+    FOR    ${var}    IN    1    2
+    ...    1    2
+        Keyword Call    1    2
+        ...    1  # comment
+        ...    2    3
+    END

--- a/tests/atest/transformers/NormalizeSeparators/test_transformer.py
+++ b/tests/atest/transformers/NormalizeSeparators/test_transformer.py
@@ -81,3 +81,8 @@ class TestNormalizeSeparators(TransformerAcceptanceTest):
         else:
             expected = "comments_skip_block_comments.robot"
         self.compare(source="comments.robot", expected=expected, config=config, target_version=">=5")
+
+    def test_flatten_lines(self):
+        # self.compare(source="test.robot", config=":flatten_lines=True")
+        # self.compare(source="rf5_syntax.robot", config=":flatten_lines=True")
+        self.compare(source="continuation_indent.robot", config=":flatten_lines=True")

--- a/tests/atest/transformers/NormalizeSeparators/test_transformer.py
+++ b/tests/atest/transformers/NormalizeSeparators/test_transformer.py
@@ -83,6 +83,4 @@ class TestNormalizeSeparators(TransformerAcceptanceTest):
         self.compare(source="comments.robot", expected=expected, config=config, target_version=">=5")
 
     def test_flatten_lines(self):
-        # self.compare(source="test.robot", config=":flatten_lines=True")
-        # self.compare(source="rf5_syntax.robot", config=":flatten_lines=True")
-        self.compare(source="continuation_indent.robot", config=":flatten_lines=True")
+        self.compare(source="flatten.robot", config=":flatten_lines=True")

--- a/tests/atest/transformers/NormalizeSeparators/test_transformer.py
+++ b/tests/atest/transformers/NormalizeSeparators/test_transformer.py
@@ -1,5 +1,6 @@
 import pytest
 
+from robotidy.utils import ROBOT_VERSION
 from tests.atest import TransformerAcceptanceTest
 
 
@@ -83,4 +84,7 @@ class TestNormalizeSeparators(TransformerAcceptanceTest):
         self.compare(source="comments.robot", expected=expected, config=config, target_version=">=5")
 
     def test_flatten_lines(self):
-        self.compare(source="flatten.robot", config=":flatten_lines=True")
+        if ROBOT_VERSION.major > 4:
+            self.compare(source="flatten.robot", config=":flatten_lines=True")
+        else:
+            self.compare(source="flatten.robot", expected="flatten_rf4.robot", config=":flatten_lines=True")


### PR DESCRIPTION
Implements one of the features from #507 

Surprisingly there wasn't option to flatten the multilines - any multiline statement was left intact (only the separators changed, unless there was transformer transforming whole statement into something else).