### PR TITLE
Fix RenameKeywords removing underscore after variable

### DIFF
--- a/docs/releasenotes/4.3.1.rst
+++ b/docs/releasenotes/4.3.1.rst
@@ -29,3 +29,15 @@ was transformed to::
     Keyword With PPoblematic SSace UUderscore CCmbination
 
 It should be now handled correctly.
+
+
+RenameKeywords does not remove whitespace after variable (#538)
+----------------------------------------------------------------
+
+``RenameKeywords`` will now correctly replace underscore with space after variables::
+
+    Embedded ${variable}_And_Remove_Underscores
+
+will be transformed to::
+
+    Embedded ${variable} And Remove Underscores

--- a/docs/releasenotes/4.3.1.rst
+++ b/docs/releasenotes/4.3.1.rst
@@ -36,8 +36,8 @@ RenameKeywords does not remove whitespace after variable (#538)
 
 ``RenameKeywords`` will now correctly replace underscore with space after variables::
 
-    Embedded ${variable}_And_Remove_Underscores
+    Embedded ${variable}_And_Removed_Underscores
 
 will be transformed to::
 
-    Embedded ${variable} And Remove Underscores
+    Embedded ${variable} And Removed Underscores

--- a/robotidy/transformers/RenameKeywords.py
+++ b/robotidy/transformers/RenameKeywords.py
@@ -94,7 +94,7 @@ class RenameKeywords(Transformer):
         else:
             new_value = self.normalize_name(token.value, is_keyword_call=is_keyword_call)
         new_value = new_value.strip()
-        if not new_value:  # do not allow renames that removes keywords altogether
+        if not new_value:  # do not allow renaming that removes keywords altogether
             return
         token.value = new_value
 

--- a/robotidy/transformers/RenameKeywords.py
+++ b/robotidy/transformers/RenameKeywords.py
@@ -93,26 +93,23 @@ class RenameKeywords(Transformer):
             new_value = self.rename_with_pattern(token.value, is_keyword_call=is_keyword_call)
         else:
             new_value = self.normalize_name(token.value, is_keyword_call=is_keyword_call)
-        if not new_value.strip():  # do not allow renames that removes keywords altogether
+        new_value = new_value.strip()
+        if not new_value:  # do not allow renames that removes keywords altogether
             return
         token.value = new_value
 
     def normalize_name(self, value, is_keyword_call):
         var_found = False
         parts = []
-        new_name, remaining = "", ""
+        remaining = ""
         for prefix, match, remaining in VariableIterator(value, ignore_errors=True):
             var_found = True
             # rename strips whitespace, so we need to preserve it if needed
             if not prefix.strip() and parts:
                 parts.extend([" ", match])
             else:
-                leading_space = " " if prefix.startswith(" ") else ""
-                trailing_space = " " if prefix.endswith(" ") else ""
-                parts.extend([leading_space, self.rename_part(prefix, is_keyword_call), trailing_space, match])
+                parts.extend([self.rename_part(prefix, is_keyword_call), match])
         if var_found:
-            if remaining.startswith(" "):
-                parts.append(" ")
             parts.append(self.rename_part(remaining, is_keyword_call))
             return "".join(parts).strip()
         return self.rename_part(value, is_keyword_call)
@@ -129,9 +126,16 @@ class RenameKeywords(Transformer):
         if self.remove_underscores:
             value = value.replace("_", " ")
             value = re.sub(r" +", " ", value)  # replace one or more spaces by one
-        value = value.strip()
+        words = []
+        split_words = value.split(" ")
         # capitalize first letter of every word, leave rest untouched
-        return "".join([a if a.isupper() else b for a, b in zip(value, string.capwords(value))])
+        for index, word in enumerate(split_words):
+            if not word:
+                if index in (0, len(split_words) - 1):  # leading and trailing whitespace
+                    words.append("")
+            else:
+                words.append(word[0].upper() + word[1:])
+        return " ".join(words)
 
     def rename_with_pattern(self, value: str, is_keyword_call: bool):
         lib_name = ""

--- a/tests/atest/transformers/RenameKeywords/expected/bug537_538.robot
+++ b/tests/atest/transformers/RenameKeywords/expected/bug537_538.robot
@@ -4,3 +4,6 @@ Keyword With Problematic Space Underscore Combination
 
 Keyword With Many Underscores
     Keyword With Many Underscores
+
+Embedded ${variable} And Remove Underscores
+    Embedded ${variable} And Remove Underscores

--- a/tests/atest/transformers/RenameKeywords/expected/rename_pattern_partial.robot
+++ b/tests/atest/transformers/RenameKeywords/expected/rename_pattern_partial.robot
@@ -48,5 +48,5 @@ All Upper Case
     Create Product DFG
 
 Underscores And. Dots
-    Foo.BAR Baz A B C
+    Foo. BAR Baz A B C
     Foo Bar BAZ

--- a/tests/atest/transformers/RenameKeywords/expected/rename_pattern_whole.robot
+++ b/tests/atest/transformers/RenameKeywords/expected/rename_pattern_whole.robot
@@ -48,5 +48,5 @@ All Upper Case
     Create Product DFG
 
 Underscores And. Dots
-    Foo.BAR Baz A B C
+    Foo. BAR Baz A B C
     Foo Bar BAZ

--- a/tests/atest/transformers/RenameKeywords/expected/test.robot
+++ b/tests/atest/transformers/RenameKeywords/expected/test.robot
@@ -47,6 +47,6 @@ All Upper Case
     Connect To System ABC
     Create Product DFG
 
-Underscores And.Dots
-    Foo.BAR Baz A B C
+Underscores And. Dots
+    Foo. BAR Baz A B C
     Foo Bar BAZ

--- a/tests/atest/transformers/RenameKeywords/expected/test_transform_library.robot
+++ b/tests/atest/transformers/RenameKeywords/expected/test_transform_library.robot
@@ -47,6 +47,6 @@ All Upper Case
     Connect To System ABC
     Create Product DFG
 
-Underscores And.Dots
-    Foo.BAR Baz A B C
+Underscores And. Dots
+    Foo. BAR Baz A B C
     Foo Bar BAZ

--- a/tests/atest/transformers/RenameKeywords/expected/with_underscores.robot
+++ b/tests/atest/transformers/RenameKeywords/expected/with_underscores.robot
@@ -47,6 +47,6 @@ All Upper Case
     Connect To System ABC
     Create Product DFG
 
-Underscores And.Dots
-    Foo.BAR Baz A B C
+Underscores And. Dots
+    Foo. BAR Baz A B C
     _Foo Bar BAZ

--- a/tests/atest/transformers/RenameKeywords/source/bug537_538.robot
+++ b/tests/atest/transformers/RenameKeywords/source/bug537_538.robot
@@ -4,3 +4,6 @@ Keyword _with_Problematic_Space_Underscore_Combination
 
 Keyword With Many Underscores
     Keyword _With_ Many_Underscores
+
+Embedded ${variable}_And_Remove_Underscores
+    Embedded ${variable}_And_Remove_Underscores

--- a/tests/atest/transformers/RenameKeywords/test_transformer.py
+++ b/tests/atest/transformers/RenameKeywords/test_transformer.py
@@ -68,5 +68,5 @@ class TestRenameKeywords(TransformerAcceptanceTest):
             source="library_embedded_var_pattern.robot",
         )
 
-    def test_bug537(self):
-        self.compare(source="bug537.robot")
+    def test_underscore_handling_bugs(self):
+        self.compare(source="bug537_538.robot")


### PR DESCRIPTION
Fixes #538 

I don't like the design of RenameKeywords rename logic but for now I just refactored and simplified it a bit (while fixing a bug).

Because of the refactor, following code:

```
Foo. BAR Baz A B C
```

will not be transformed to:

```
Foo.BAR Baz A B C
```

(it will not be transformed, space after dot will be preserved). I believe it's fine since removing the space after dot wasn't intended behaviour.