### PR TITLE
Resolve inconsinstency with min_width working as (not existing before) fixed_width

### DIFF
--- a/docs/releasenotes/unreleased/fixes.4.rst
+++ b/docs/releasenotes/unreleased/fixes.4.rst
@@ -1,0 +1,10 @@
+Minimal width of the column in AlignVariablesSection and AlignSettingsSection (#558)
+------------------------------------------------------------------------------------
+
+``AlignVariablesSection`` and ``AlignSettingsSection`` transformers use ``min_width`` parameter. Originally it didn't
+work as ``min_width`` but more as ``fixed_width`` parameter. That's why we are now introducing new parameter
+(``fixed_width``) that will work same as previous ``min_width``. ``min_width`` is now fixed and is used to configure
+minimal width of the aligned column.
+
+If you are relying on ``min_width`` to set fixed width of the column, rename it to ``fixed_width`` in your
+configuration.

--- a/docs/source/transformers/AlignSettingsSection.rst
+++ b/docs/source/transformers/AlignSettingsSection.rst
@@ -165,9 +165,9 @@ You can configure the indent or disable it by setting ``argument_indent`` to 0.
 
 Fixed width of column
 -------------------------
-It's possible to set fixed minimal width of column. To configure it use ``min_width`` parameter::
+It's possible to set fixed width of the column. To configure it use ``fixed_width`` parameter::
 
-    robotidy --configure AlignSettingsSection:min_width=30 src
+    robotidy --configure AlignSettingsSection:fixed_width=30 src
 
 This configuration respects ``up_to_column`` parameter but ignores ``argument_indent``.
 
@@ -196,6 +196,40 @@ This configuration respects ``up_to_column`` parameter but ignores ``argument_in
             Documentation                Example using the space separated format.
             ...                          and this documentation is multiline
             ...                          where this line should go I wonder?
+
+Minimal width of column
+-------------------------
+It's possible to set minimal width of the column. To configure it use ``min_width`` parameter::
+
+    robotidy --configure AlignSettingsSection:min_width=20 src
+
+This configuration respects ``up_to_column`` parameter.
+
+.. tab-set::
+
+    .. tab-item:: Before
+
+        .. code:: robotframework
+
+            *** Settings ***
+            Library    CustomLibrary   WITH NAME  name
+            Library    ArgsedLibrary   ${1}  ${2}  ${3}
+
+            Documentation     Example using the space separated format.
+            ...  and this documentation is multiline
+            ...  where this line should go I wonder?
+
+    .. tab-item:: After
+
+        .. code:: robotframework
+
+            *** Settings ***
+            Library             CustomLibrary   WITH NAME  name
+            Library             ArgsedLibrary   ${1}  ${2}  ${3}
+
+            Documentation       Example using the space separated format.
+            ...                 and this documentation is multiline
+            ...                 where this line should go I wonder?
 
 Select lines to transform
 -------------------------

--- a/docs/source/transformers/AlignVariablesSection.rst
+++ b/docs/source/transformers/AlignVariablesSection.rst
@@ -123,12 +123,11 @@ Using above configuration code will be aligned in following way:
             ${LONGER_NAME_THAT_GOES_AND_GOES}       longer value that goes and goes
             &{SOME_DICT}    key=value  key2=value
 
-
 Fixed width of column
 -------------------------
-It's possible to set fixed minimal width of column. To configure it use ``min_width`` parameter::
+It's possible to set fixed width of the column. To configure it use ``fixed_width`` parameter::
 
-    robotidy --configure AlignVariablesSection:min_width=20 src
+    robotidy --configure AlignVariablesSection:fixed_width=20 src
 
 This configuration respects ``up_to_column`` parameter:
 
@@ -159,6 +158,78 @@ This configuration respects ``up_to_column`` parameter:
             ${VARIABLE 1}       10    # comment
             @{LIST}             a    b    c    d
             ${LONGER_NAME_THAT_GOES_AND_GOES}    longer value that goes and goes
+
+            &{MULTILINE}        a=b
+            ...                 b=c
+            ...                 d=1
+
+Minimal width of column
+-------------------------
+It's possible to set minimal width of the the column. To configure it use ``min_width`` parameter::
+
+    robotidy --configure AlignVariablesSection:min_width=20 src
+
+This configuration respects ``up_to_column`` parameter. Example where there is variable longer than ``min_width``:
+
+.. tab-set::
+
+    .. tab-item:: Before
+
+        .. code:: robotframework
+
+            *** Variables ***
+            # some comment
+
+            ${VARIABLE 1}    10    # comment
+            @{LIST}                                 a    b    c    d
+            ${LONGER_NAME_THAT_GOES_AND_GOES}       longer value that goes and goes
+
+            &{MULTILINE}    a=b
+            ...     b=c
+            ...     d=1
+
+    .. tab-item:: After
+
+        .. code:: robotframework
+
+            *** Variables ***
+            # some comment
+
+            ${VARIABLE 1}                        10    # comment
+            @{LIST}                              a    b    c    d
+            ${LONGER_NAME_THAT_GOES_AND_GOES}    longer value that goes and goes
+
+            &{MULTILINE}                          a=b
+            ...                                   b=c
+            ...                                   d=1
+
+Example where all variables are shorter than ``min_width``:
+
+.. tab-set::
+
+    .. tab-item:: Before
+
+        .. code:: robotframework
+
+            *** Variables ***
+            # some comment
+
+            ${VARIABLE 1}    10    # comment
+            @{LIST}                                 a    b    c    d
+
+            &{MULTILINE}    a=b
+            ...     b=c
+            ...     d=1
+
+    .. tab-item:: After
+
+        .. code:: robotframework
+
+            *** Variables ***
+            # some comment
+
+            ${VARIABLE 1}       10    # comment
+            @{LIST}             a    b    c    d
 
             &{MULTILINE}        a=b
             ...                 b=c

--- a/robotidy/transformers/AlignSettingsSection.py
+++ b/robotidy/transformers/AlignSettingsSection.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from robot.api.parsing import Token
+from robot.api.parsing import Documentation, Token
 from robot.parsing.model import Statement
 
 from robotidy.disablers import skip_section_if_disabled
@@ -70,11 +70,12 @@ class AlignSettingsSection(Transformer):
         Token.VARIABLES,
     }
 
-    def __init__(self, up_to_column: int = 2, argument_indent: int = 4, min_width: int = None):
+    def __init__(self, up_to_column: int = 2, argument_indent: int = 4, min_width: int = None, fixed_width: int = None):
         super().__init__()
         self.up_to_column = up_to_column - 1
         self.argument_indent = argument_indent
         self.min_width = min_width
+        self.fixed_width = fixed_width
 
     @skip_section_if_disabled
     def visit_SettingSection(self, node):  # noqa
@@ -131,8 +132,8 @@ class AlignSettingsSection(Transformer):
 
     def calc_separator(self, index, up_to, indent_arg, token, look_up):
         if index < up_to:
-            if self.min_width:
-                return max(self.min_width - len(token.value), self.formatting_config.space_count) * " "
+            if self.fixed_width:
+                return max(self.fixed_width - len(token.value), self.formatting_config.space_count) * " "
             arg_indent = self.argument_indent if indent_arg else 0
             if indent_arg and index != 0:
                 return (
@@ -159,5 +160,7 @@ class AlignSettingsSection(Transformer):
                 else:
                     up_to = len(line)
                 for index, token in enumerate(line[:up_to]):
+                    if self.min_width:
+                        look_up[index] = self.min_width - 4
                     look_up[index] = max(look_up[index], len(token.value))
         return {index: round_to_four(length) for index, length in look_up.items()}

--- a/robotidy/transformers/AlignSettingsSection.py
+++ b/robotidy/transformers/AlignSettingsSection.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from robot.api.parsing import Documentation, Token
+from robot.api.parsing import Token
 from robot.parsing.model import Statement
 
 from robotidy.disablers import skip_section_if_disabled
@@ -160,7 +160,7 @@ class AlignSettingsSection(Transformer):
                 else:
                     up_to = len(line)
                 for index, token in enumerate(line[:up_to]):
-                    if self.min_width:
-                        look_up[index] = self.min_width - 4
                     look_up[index] = max(look_up[index], len(token.value))
+        if self.min_width:
+            look_up = {index: max(length, self.min_width - 4) for index, length in look_up.items()}
         return {index: round_to_four(length) for index, length in look_up.items()}

--- a/robotidy/transformers/AlignVariablesSection.py
+++ b/robotidy/transformers/AlignVariablesSection.py
@@ -44,10 +44,11 @@ class AlignVariablesSection(Transformer):
     To align all columns set ``up_to_column`` to 0.
     """
 
-    def __init__(self, up_to_column: int = 2, skip_types: str = "", min_width: int = None):
+    def __init__(self, up_to_column: int = 2, skip_types: str = "", min_width: int = None, fixed_width: int = None):
         super().__init__()
         self.up_to_column = up_to_column - 1
         self.min_width = min_width
+        self.fixed_width = fixed_width
         self.skip_types = self.parse_skip_types(skip_types)
 
     def parse_skip_types(self, skip_types):
@@ -117,8 +118,8 @@ class AlignVariablesSection(Transformer):
 
     def calc_separator(self, index, up_to, token, look_up):
         if index < up_to:
-            if self.min_width:
-                return max(self.min_width - len(token.value), self.formatting_config.space_count) * " "
+            if self.fixed_width:
+                return max(self.fixed_width - len(token.value), self.formatting_config.space_count) * " "
             return (look_up[index] - len(token.value) + 4) * " "
         else:
             return self.formatting_config.space_count * " "
@@ -129,5 +130,7 @@ class AlignVariablesSection(Transformer):
             for line in st:
                 up_to = self.up_to_column if self.up_to_column != -1 else len(line)
                 for index, token in enumerate(line[:up_to]):
+                    if self.min_width:
+                        look_up[index] = self.min_width - 4
                     look_up[index] = max(look_up[index], len(token.value))
         return {index: round_to_four(length) for index, length in look_up.items()}

--- a/robotidy/transformers/AlignVariablesSection.py
+++ b/robotidy/transformers/AlignVariablesSection.py
@@ -130,7 +130,7 @@ class AlignVariablesSection(Transformer):
             for line in st:
                 up_to = self.up_to_column if self.up_to_column != -1 else len(line)
                 for index, token in enumerate(line[:up_to]):
-                    if self.min_width:
-                        look_up[index] = self.min_width - 4
                     look_up[index] = max(look_up[index], len(token.value))
+        if self.min_width:
+            look_up = {index: max(length, self.min_width - 4) for index, length in look_up.items()}
         return {index: round_to_four(length) for index, length in look_up.items()}

--- a/tests/atest/transformers/AlignSettingsSection/expected/test_min_width.robot
+++ b/tests/atest/transformers/AlignSettingsSection/expected/test_min_width.robot
@@ -1,0 +1,30 @@
+*** Settings ***
+# whole line comment that should be ignored
+Resource            ..${/}resources${/}resource.robot
+Library             SeleniumLibrary
+Library             Mylibrary.py
+Variables           variables.py
+Test Timeout        1 min
+
+# this should be left aligned
+Library             CustomLibrary    WITH NAME    name
+Library             ArgsedLibrary    ${1}    ${2}    ${3}
+
+Documentation       Example using the space separated format.
+...                 and this documentation is multiline
+...                 where this line should go I wonder?
+
+Default Tags        default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
+Test Setup          Open Application    App A
+Test Teardown       Close Application
+
+Metadata            Version    2.0
+Metadata            More Info    For more information about *Robot Framework* see http://robotframework.org
+Metadata            Executed At    {HOST}
+# this should be left aligned
+Test Template
+
+*** Keywords ***
+Keyword
+    Keyword  A
+    Keyword    B

--- a/tests/atest/transformers/AlignSettingsSection/expected/test_min_width_50_width.robot
+++ b/tests/atest/transformers/AlignSettingsSection/expected/test_min_width_50_width.robot
@@ -1,0 +1,30 @@
+*** Settings ***
+# whole line comment that should be ignored
+Resource                                            ..${/}resources${/}resource.robot
+Library                                             SeleniumLibrary
+Library                                             Mylibrary.py
+Variables                                           variables.py
+Test Timeout                                        1 min
+
+# this should be left aligned
+Library                                             CustomLibrary    WITH NAME    name
+Library                                             ArgsedLibrary    ${1}    ${2}    ${3}
+
+Documentation                                       Example using the space separated format.
+...                                                 and this documentation is multiline
+...                                                 where this line should go I wonder?
+
+Default Tags                                        default tag 1    default tag 2    default tag 3    default tag 4    default tag 5
+Test Setup                                          Open Application    App A
+Test Teardown                                       Close Application
+
+Metadata                                            Version    2.0
+Metadata                                            More Info    For more information about *Robot Framework* see http://robotframework.org
+Metadata                                            Executed At    {HOST}
+# this should be left aligned
+Test Template
+
+*** Keywords ***
+Keyword
+    Keyword  A
+    Keyword    B

--- a/tests/atest/transformers/AlignSettingsSection/test_transformer.py
+++ b/tests/atest/transformers/AlignSettingsSection/test_transformer.py
@@ -58,13 +58,13 @@ class TestAlignSettingsSection(TransformerAcceptanceTest):
         self.compare(source="blank_line_and_whitespace.robot")
 
     def test_fixed_test(self):
-        self.compare(source="test.robot", expected="test_fixed.robot", config=":min_width=35")
+        self.compare(source="test.robot", expected="test_fixed.robot", config=":fixed_width=35")
 
     def test_fixed_all_columns(self):
         self.compare(
             source="test.robot",
             expected="all_columns_fixed.robot",
-            config=":min_width=20:up_to_column=0",
+            config=":fixed_width=20:up_to_column=0",
         )
 
     def test_disablers(self):
@@ -72,3 +72,11 @@ class TestAlignSettingsSection(TransformerAcceptanceTest):
 
     def test_argument_indents(self):
         self.compare(source="argument_indents.robot")
+
+    @pytest.mark.parametrize("min_width", [0, 1, 20])
+    def test_min_width_shorter(self, min_width):
+        self.compare(source="test.robot", expected="test_min_width.robot", config=f":min_width={min_width}")
+
+    @pytest.mark.parametrize("min_width", [49, 50, 51, 52])
+    def test_min_width_longer(self, min_width):
+        self.compare(source="test.robot", expected="test_min_width_50_width.robot", config=f":min_width={min_width}")

--- a/tests/atest/transformers/AlignVariablesSection/expected/tests_min_width.robot
+++ b/tests/atest/transformers/AlignVariablesSection/expected/tests_min_width.robot
@@ -1,0 +1,16 @@
+*** Variables ***
+# some comment
+
+${VARIABLE 1}                           10    # comment
+@{LIST}                                 a    b    c    d
+${LONGER_NAME_THAT_GOES_AND_GOES}       longer value that goes and goes
+
+&{MULTILINE}                            a=b
+...                                     b=c
+...                                     d=1
+${invalid}
+${invalid_more}
+
+# should be left aligned
+# should be left aligned
+${variable}                             1

--- a/tests/atest/transformers/AlignVariablesSection/expected/tests_min_width_50_width.robot
+++ b/tests/atest/transformers/AlignVariablesSection/expected/tests_min_width_50_width.robot
@@ -1,0 +1,16 @@
+*** Variables ***
+# some comment
+
+${VARIABLE 1}                                       10    # comment
+@{LIST}                                             a    b    c    d
+${LONGER_NAME_THAT_GOES_AND_GOES}                   longer value that goes and goes
+
+&{MULTILINE}                                        a=b
+...                                                 b=c
+...                                                 d=1
+${invalid}
+${invalid_more}
+
+# should be left aligned
+# should be left aligned
+${variable}                                         1

--- a/tests/atest/transformers/AlignVariablesSection/test_transformer.py
+++ b/tests/atest/transformers/AlignVariablesSection/test_transformer.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests.atest import TransformerAcceptanceTest
 
 
@@ -50,17 +52,25 @@ class TestAlignVariablesSection(TransformerAcceptanceTest):
         self.compare(source="multiline_skip.robot", config=":skip_types=list,dict")
 
     def test_fixed_tests(self):
-        self.compare(source="tests.robot", expected="tests_fixed.robot", config=":min_width=30")
+        self.compare(source="tests.robot", expected="tests_fixed.robot", config=":fixed_width=30")
 
     def test_fixed_tests_zero(self):
-        self.compare(source="tests.robot", expected="tests_fixed_one.robot", config=":min_width=1")
+        self.compare(source="tests.robot", expected="tests_fixed_one.robot", config=":fixed_width=1")
 
     def test_fixed_all_columns(self):
         self.compare(
             source="tests.robot",
             expected="all_columns_fixed.robot",
-            config=":min_width=20:up_to_column=0",
+            config=":fixed_width=20:up_to_column=0",
         )
 
     def test_disablers(self):
         self.compare(source="tests_disablers.robot")
+
+    @pytest.mark.parametrize("min_width", [0, 1, 20])
+    def test_min_width_shorter(self, min_width):
+        self.compare(source="tests.robot", expected="tests_min_width.robot", config=f":min_width={min_width}")
+
+    @pytest.mark.parametrize("min_width", [49, 50, 51, 52])
+    def test_min_width_longer(self, min_width):
+        self.compare(source="tests.robot", expected="tests_min_width_50_width.robot", config=f":min_width={min_width}")


### PR DESCRIPTION
For ``AlignVariablesSection`` and ``AlignSettingsSection`` transformers.

Fixes #558 