### PR TITLE
Fix deprecated readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,10 +1,15 @@
+---
 version: 2
 
 sphinx:
   configuration: docs/source/conf.py
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"
+
 python:
-  version: 3.7
   install:
     - method: pip
       path: .[doc]


### PR DESCRIPTION
Our documentation build failed because of https://blog.readthedocs.com/use-build-os-config/ (we are quite 'lucky' since today is the first brownout session and another will be in a month)