### PR TITLE
Removed redundant fork in AST traversing in SplitTooLongLine

### DIFF
--- a/robotidy/transformers/InlineIf.py
+++ b/robotidy/transformers/InlineIf.py
@@ -76,8 +76,6 @@ class InlineIf(Transformer):
         if self.is_inline(node):
             return self.handle_inline(node)
         self.generic_visit(node)
-        if node.orelse:
-            self.generic_visit(node.orelse)
         if self.no_end(node):
             return node
         indent = node.header.tokens[0]

--- a/robotidy/transformers/SplitTooLongLine.py
+++ b/robotidy/transformers/SplitTooLongLine.py
@@ -121,8 +121,6 @@ class SplitTooLongLine(Transformer):
     def visit_If(self, node):  # noqa
         if self.is_inline(node):
             return node
-        if node.orelse:
-            self.generic_visit(node.orelse)
         return self.generic_visit(node)
 
     @staticmethod


### PR DESCRIPTION
closes #578

These two innocuous lines meant that processing time increases exponentially with the number of `ELSE IF`s, causing performance issues in specific situations.

I counted the number of visits for each ELSE-IF in my file. There are a total of 30 branches in this file: 1 `IF` followed by 29 `ELSE IF`s. I hashed each keyword node coming through the `visit_KeywordCall` function and counted how often these hashes occurred

```yaml
visitCount: 1
visitCount: 2
visitCount: 5
visitCount: 5
visitCount: 13
visitCount: 13
visitCount: 34
visitCount: 34
visitCount: 34
visitCount: 34
visitCount: 34
visitCount: 34
visitCount: 89
visitCount: 89
visitCount: 233
visitCount: 233
visitCount: 610
visitCount: 610
visitCount: 1597
visitCount: 1597
visitCount: 4181
visitCount: 4181
visitCount: 10946
visitCount: 10946
visitCount: 28657
visitCount: 28657
visitCount: 75025
visitCount: 75025
visitCount: 196418
visitCount: 196418
visitCount: 514229
visitCount: 514229
visitCount: 514229
visitCount: 514229
visitCount: 514229
visitCount: 514229
visitCount: 1346269
visitCount: 1346269
visitCount: 832040
visitCount: 832040
visitCount: 317811
visitCount: 317811
visitCount: 121393
visitCount: 121393
visitCount: 46368
visitCount: 46368
visitCount: 17711
visitCount: 17711
visitCount: 6765
visitCount: 6765
visitCount: 2584
visitCount: 2584
visitCount: 987
visitCount: 987
visitCount: 987
visitCount: 377
visitCount: 377
visitCount: 144
visitCount: 144
visitCount: 55
visitCount: 55
visitCount: 21
visitCount: 21
visitCount: 8
visitCount: 8
visitCount: 3
visitCount: 3
visitCount: 1
visitCount: 1
```

Note how some keyword nodes are visited over a million times! This is why it took so long for my file to format.

And all of this was caused by 2 lines that make a lot of sense on the surface :)