### PR TITLE
RenameKeyword: add convert_title_case flag to prevent Title Case conversion

### DIFF
--- a/docs/source/transformers/RenameKeywords.rst
+++ b/docs/source/transformers/RenameKeywords.rst
@@ -13,6 +13,10 @@ You can keep underscores if you set remove_underscores to False::
 
     robotidy --transform RenameKeywords -c RenameKeywords:remove_underscores=False .
 
+You can leave the keyword capitilization as is by setting convert_title_case to False::
+
+    robotidy --transform RenameKeywords -c RenameKeywords:convert_title_case=False .
+
 Library name
 ------------
 By default library name in keyword name is ignored. Anything before the last dot in the name is considered as a library name.

--- a/robotidy/transformers/RenameKeywords.py
+++ b/robotidy/transformers/RenameKeywords.py
@@ -129,22 +129,19 @@ class RenameKeywords(Transformer):
             value = value.replace("_", " ")
             value = re.sub(r" +", " ", value)  # replace one or more spaces by one
 
-        if self.convert_title_case:
-            words = []
-            split_words = value.split(" ")
+        if not self.convert_title_case:
+            return value
+        words = []
+        split_words = value.split(" ")
 
-            # capitalize first letter of every word, leave rest untouched
-            for index, word in enumerate(split_words):
-                if not word:
-                    if index in (0, len(split_words) - 1):  # leading and trailing whitespace
-                        words.append("")
-                else:
-                    words.append(word[0].upper() + word[1:])
-            result = " ".join(words)
-        else:
-            result = value
-
-        return result
+        # capitalize first letter of every word, leave rest untouched
+        for index, word in enumerate(split_words):
+            if not word:
+                if index in (0, len(split_words) - 1):  # leading and trailing whitespace
+                    words.append("")
+            else:
+                words.append(word[0].upper() + word[1:])
+       return " ".join(words)
 
     def rename_with_pattern(self, value: str, is_keyword_call: bool):
         lib_name = ""

--- a/robotidy/transformers/RenameKeywords.py
+++ b/robotidy/transformers/RenameKeywords.py
@@ -131,9 +131,9 @@ class RenameKeywords(Transformer):
 
         if not self.convert_title_case:
             return value
+
         words = []
         split_words = value.split(" ")
-
         # capitalize first letter of every word, leave rest untouched
         for index, word in enumerate(split_words):
             if not word:

--- a/robotidy/transformers/RenameKeywords.py
+++ b/robotidy/transformers/RenameKeywords.py
@@ -141,7 +141,7 @@ class RenameKeywords(Transformer):
                     words.append("")
             else:
                 words.append(word[0].upper() + word[1:])
-       return " ".join(words)
+        return " ".join(words)
 
     def rename_with_pattern(self, value: str, is_keyword_call: bool):
         lib_name = ""

--- a/robotidy/transformers/RenameKeywords.py
+++ b/robotidy/transformers/RenameKeywords.py
@@ -16,7 +16,8 @@ class RenameKeywords(Transformer):
 
     Title Case is applied to keyword name and underscores are replaced by spaces.
 
-    You can keep underscores if you set remove_underscores to False:
+    To retain the keyword upper/lower case, set convert_title_case to False.
+    To keep underscores, set remove_underscores to False:
 
     ```
     robotidy --transform RenameKeywords -c RenameKeywords:remove_underscores=False .
@@ -57,10 +58,12 @@ class RenameKeywords(Transformer):
         replace_to: Optional[str] = None,
         remove_underscores: bool = True,
         ignore_library: bool = True,
+        convert_title_case: bool = True,
     ):
         super().__init__()
         self.ignore_library = ignore_library
         self.remove_underscores = remove_underscores
+        self.convert_title_case = convert_title_case
         self.replace_pattern = self.parse_pattern(replace_pattern)
         self.replace_to = "" if replace_to is None else replace_to
         self.run_keywords = get_run_keywords()
@@ -125,16 +128,23 @@ class RenameKeywords(Transformer):
         if self.remove_underscores:
             value = value.replace("_", " ")
             value = re.sub(r" +", " ", value)  # replace one or more spaces by one
-        words = []
-        split_words = value.split(" ")
-        # capitalize first letter of every word, leave rest untouched
-        for index, word in enumerate(split_words):
-            if not word:
-                if index in (0, len(split_words) - 1):  # leading and trailing whitespace
-                    words.append("")
-            else:
-                words.append(word[0].upper() + word[1:])
-        return " ".join(words)
+
+        if self.convert_title_case:
+            words = []
+            split_words = value.split(" ")
+
+            # capitalize first letter of every word, leave rest untouched
+            for index, word in enumerate(split_words):
+                if not word:
+                    if index in (0, len(split_words) - 1):  # leading and trailing whitespace
+                        words.append("")
+                else:
+                    words.append(word[0].upper() + word[1:])
+            result = " ".join(words)
+        else:
+            result = value
+
+        return result
 
     def rename_with_pattern(self, value: str, is_keyword_call: bool):
         lib_name = ""

--- a/tests/atest/transformers/RenameKeywords/expected/no_title_case.robot
+++ b/tests/atest/transformers/RenameKeywords/expected/no_title_case.robot
@@ -1,0 +1,9 @@
+*** Keywords ***
+lower case stays
+    no operation
+
+Upper Case stays
+    No Operation
+
+Underscores will be removed
+    No operation

--- a/tests/atest/transformers/RenameKeywords/source/no_title_case.robot
+++ b/tests/atest/transformers/RenameKeywords/source/no_title_case.robot
@@ -1,0 +1,9 @@
+*** Keywords ***
+lower case stays
+    no operation
+
+Upper Case stays
+    No Operation
+
+Underscores_will_be_removed
+    No operation

--- a/tests/atest/transformers/RenameKeywords/test_transformer.py
+++ b/tests/atest/transformers/RenameKeywords/test_transformer.py
@@ -70,3 +70,9 @@ class TestRenameKeywords(TransformerAcceptanceTest):
 
     def test_underscore_handling_bugs(self):
         self.compare(source="bug537_538.robot")
+
+    def test_no_title_case(self):
+        self.compare(
+            source="no_title_case.robot",
+            config=":convert_title_case=False",
+        )


### PR DESCRIPTION
we have a use case where we only want RenameKeywords to support keyword deprecation, i.e. to translate old to new keywords via `replace_pattern`. The automatic title case conversion is not desired as we have not adopted this style in our keyword library. hence suggesting a new flag