### PR TITLE
Limit robotframework dependency to version less than 8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     include_package_data=True,
     python_requires=">=3.7",
     install_requires=[
-        "robotframework>=4.0",
+        "robotframework>=4.0,<8.0",
         "click==8.1.*",
         "colorama>=0.4.3,<0.4.7",
         "pathspec>=0.9.0,<0.12.2",


### PR DESCRIPTION
When robotframework 7 was released the pre-commit hook broke because robotidy didn't support the new major version. This PR limits robotframework requires to version less than 8.0 to prevent robotidy breaking we a new major version of robotframework with breaking changes is released.