### PR TITLE
Add output of number of skipped files

### DIFF
--- a/tests/utest/test_cli.py
+++ b/tests/utest/test_cli.py
@@ -358,6 +358,7 @@ class TestCli:
         # overwrite input which is read-only file
         result = run_tidy([str(source)], overwrite_input=True)
         assert "Permission denied" in result.output
+        assert "\n0 files reformatted, 0 files left unchanged. 1 file skipped.\n" in result.output
 
     @pytest.mark.parametrize("color_flag", ["--color", "--no-color", None])
     @pytest.mark.parametrize("color_env", [True, False])


### PR DESCRIPTION
Currently, files that were skipped would still be counted in the number of reformatted files. This subtracts the number of skipped files from the transformed files and echoes the number of skipped files if any files were skipped.