### PR TITLE
Fix SplitTooLongLine not handling invalid keyword name

### DIFF
--- a/docs/releasenotes/unreleased/fixes.3.rst
+++ b/docs/releasenotes/unreleased/fixes.3.rst
@@ -1,0 +1,9 @@
+SplitTooLongLine fails with fatal exception when splitting invalid keyword (#659)
+----------------------------------------------------------------------------------
+
+``SplitTooLongLine`` did not handle invalid syntax where keyword name was omitted::
+    Keyword
+        ${arg}    ${second_arg}
+        ...    ${third_arg}
+
+Such syntax will now be ignored and will not cause fatal exception.

--- a/robotidy/transformers/SplitTooLongLine.py
+++ b/robotidy/transformers/SplitTooLongLine.py
@@ -318,6 +318,8 @@ class SplitTooLongLine(Transformer):
         indent = node.tokens[0]
 
         keyword = node.get_token(Token.KEYWORD)
+        if not keyword:
+            return node
         # check if assign tokens needs to be split too
         assign = node.get_tokens(Token.ASSIGN)
         line = [indent, *self.join_on_separator(assign, separator), keyword]

--- a/tests/atest/transformers/SplitTooLongLine/expected/settings_on_every_arg.robot
+++ b/tests/atest/transformers/SplitTooLongLine/expected/settings_on_every_arg.robot
@@ -86,3 +86,10 @@ Comment that goes over the allowed length
     ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     # this is long comment and it should be ignored with --skip-comments
     Step
+
+Invalid arguments
+   [Arguments]    ${Multiline_Argument1}    ${Multiline_Argument2}    ${Multiline_Argument3}    ${Multiline_Argument4}
+                    ${Multiline_Argument5}    ${Multiline_Argument6}    ${Multiline_Argument7}    ${Multiline_Argument8}
+    ...    ${Multiline_Argument9}    ${Multiline_Argument10}    ${Multiline_Argument11}    ${Multiline_Argument12}
+    ...    ${Multiline_Argument13}    ${Multiline_Argument14}    ${Multiline_Argument15}    ${Multiline_Argument16}
+   [Documentation]    Missing continuation line.

--- a/tests/atest/transformers/SplitTooLongLine/expected/settings_skip_tests.robot
+++ b/tests/atest/transformers/SplitTooLongLine/expected/settings_skip_tests.robot
@@ -42,3 +42,10 @@ Comment that goes over the allowed length
     ...    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     # this is long comment and it should be ignored with --skip-comments
     Step
+
+Invalid arguments
+   [Arguments]    ${Multiline_Argument1}    ${Multiline_Argument2}    ${Multiline_Argument3}    ${Multiline_Argument4}
+                    ${Multiline_Argument5}    ${Multiline_Argument6}    ${Multiline_Argument7}    ${Multiline_Argument8}
+    ...    ${Multiline_Argument9}    ${Multiline_Argument10}    ${Multiline_Argument11}    ${Multiline_Argument12}
+    ...    ${Multiline_Argument13}    ${Multiline_Argument14}    ${Multiline_Argument15}    ${Multiline_Argument16}
+   [Documentation]    Missing continuation line.

--- a/tests/atest/transformers/SplitTooLongLine/expected/settings_until_line_length.robot
+++ b/tests/atest/transformers/SplitTooLongLine/expected/settings_until_line_length.robot
@@ -43,3 +43,10 @@ Comment that goes over the allowed length
     [Arguments]    ${short}    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}
     # this is long comment and it should be ignored with --skip-comments
     Step
+
+Invalid arguments
+   [Arguments]    ${Multiline_Argument1}    ${Multiline_Argument2}    ${Multiline_Argument3}    ${Multiline_Argument4}
+                    ${Multiline_Argument5}    ${Multiline_Argument6}    ${Multiline_Argument7}    ${Multiline_Argument8}
+    ...    ${Multiline_Argument9}    ${Multiline_Argument10}    ${Multiline_Argument11}    ${Multiline_Argument12}
+    ...    ${Multiline_Argument13}    ${Multiline_Argument14}    ${Multiline_Argument15}    ${Multiline_Argument16}
+   [Documentation]    Missing continuation line.

--- a/tests/atest/transformers/SplitTooLongLine/expected/settings_until_line_length_skip_comments.robot
+++ b/tests/atest/transformers/SplitTooLongLine/expected/settings_until_line_length_skip_comments.robot
@@ -42,3 +42,10 @@ Arguments single line over limit
 Comment that goes over the allowed length
     [Arguments]    ${short}    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}  # this is long comment and it should be ignored with --skip-comments
     Step
+
+Invalid arguments
+   [Arguments]    ${Multiline_Argument1}    ${Multiline_Argument2}    ${Multiline_Argument3}    ${Multiline_Argument4}
+                    ${Multiline_Argument5}    ${Multiline_Argument6}    ${Multiline_Argument7}    ${Multiline_Argument8}
+    ...    ${Multiline_Argument9}    ${Multiline_Argument10}    ${Multiline_Argument11}    ${Multiline_Argument12}
+    ...    ${Multiline_Argument13}    ${Multiline_Argument14}    ${Multiline_Argument15}    ${Multiline_Argument16}
+   [Documentation]    Missing continuation line.

--- a/tests/atest/transformers/SplitTooLongLine/source/settings.robot
+++ b/tests/atest/transformers/SplitTooLongLine/source/settings.robot
@@ -34,3 +34,10 @@ Arguments single line over limit
 Comment that goes over the allowed length
     [Arguments]    ${short}    ${veryLongAndJavaLikeArgumentThatWillGoOverAllowedLength}  # this is long comment and it should be ignored with --skip-comments
     Step
+
+Invalid arguments
+   [Arguments]    ${Multiline_Argument1}    ${Multiline_Argument2}    ${Multiline_Argument3}    ${Multiline_Argument4}
+                    ${Multiline_Argument5}    ${Multiline_Argument6}    ${Multiline_Argument7}    ${Multiline_Argument8}
+    ...    ${Multiline_Argument9}    ${Multiline_Argument10}    ${Multiline_Argument11}    ${Multiline_Argument12}
+    ...    ${Multiline_Argument13}    ${Multiline_Argument14}    ${Multiline_Argument15}    ${Multiline_Argument16}
+   [Documentation]    Missing continuation line.

--- a/tests/e2e/test_transform_stability.py
+++ b/tests/e2e/test_transform_stability.py
@@ -66,7 +66,7 @@ RERUN_NEEDED = {
     "SplitTooLongLine": {"continuation_indent": 2, "disablers": 2, "tests": 2, "comments": 2, "settings": 2},
     "Translate": {"pl_language_header": 2},
 }
-SKIP_TESTS_4 = {"ReplaceReturns": {"test"}, "GenerateDocumentation": {"test": 2}}
+SKIP_TESTS_4 = {"ReplaceReturns": {"test"}, "GenerateDocumentation": {"test": 2}, "SplitTooLongLine": {"settings"}}
 SKIP_TESTS = {
     "ReplaceRunKeywordIf": {"invalid_data"},
     "SplitTooLongLine": {"variables"},


### PR DESCRIPTION
Fixes #659 