### PR TITLE
Reduce codespell and pytest warnings

### DIFF
--- a/tests/atest/transformers/AlignKeywordsSection/expected/documentation_auto_align_first_col.robot
+++ b/tests/atest/transformers/AlignKeywordsSection/expected/documentation_auto_align_first_col.robot
@@ -8,7 +8,7 @@ Example of alignment to second column of Documentation
     ...                 note that you must give some unique column/value pair that is used to select the row
     ...
     ...                 == Examples ==
-    ...                 # makes sure chechbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
+    ...                 # makes sure checkbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
     ...                 Table_CheckboxUnSelect  Owner      Name    NORDEA FINANS
 
 Keyword with documentation and keyword calls

--- a/tests/atest/transformers/AlignKeywordsSection/expected/documentation_auto_skip.robot
+++ b/tests/atest/transformers/AlignKeywordsSection/expected/documentation_auto_skip.robot
@@ -8,7 +8,7 @@ Example of alignment to second column of Documentation
     ...                 note that you must give some unique column/value pair that is used to select the row
     ...
     ...                 == Examples ==
-    ...                 # makes sure chechbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
+    ...                 # makes sure checkbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
     ...                 Table_CheckboxUnSelect  Owner      Name    NORDEA FINANS
 
 Keyword with documentation and keyword calls

--- a/tests/atest/transformers/AlignKeywordsSection/expected/documentation_fixed_align_first_col.robot
+++ b/tests/atest/transformers/AlignKeywordsSection/expected/documentation_fixed_align_first_col.robot
@@ -8,7 +8,7 @@ Example of alignment to second column of Documentation
     ...                     note that you must give some unique column/value pair that is used to select the row
     ...
     ...                     == Examples ==
-    ...                     # makes sure chechbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
+    ...                     # makes sure checkbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
     ...                     Table_CheckboxUnSelect  Owner      Name    NORDEA FINANS
 
 Keyword with documentation and keyword calls

--- a/tests/atest/transformers/AlignKeywordsSection/expected/documentation_fixed_skip.robot
+++ b/tests/atest/transformers/AlignKeywordsSection/expected/documentation_fixed_skip.robot
@@ -8,7 +8,7 @@ Example of alignment to second column of Documentation
     ...                 note that you must give some unique column/value pair that is used to select the row
     ...
     ...                 == Examples ==
-    ...                 # makes sure chechbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
+    ...                 # makes sure checkbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
     ...                 Table_CheckboxUnSelect  Owner      Name    NORDEA FINANS
 
 Keyword with documentation and keyword calls

--- a/tests/atest/transformers/AlignKeywordsSection/source/documentation.robot
+++ b/tests/atest/transformers/AlignKeywordsSection/source/documentation.robot
@@ -8,7 +8,7 @@ Example of alignment to second column of Documentation
     ...                 note that you must give some unique column/value pair that is used to select the row
     ...
     ...                 == Examples ==
-    ...                 # makes sure chechbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
+    ...                 # makes sure checkbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
     ...                 Table_CheckboxUnSelect  Owner      Name    NORDEA FINANS
 
 Keyword with documentation and keyword calls

--- a/tests/atest/transformers/AlignTestCasesSection/expected/documentation_auto_align_first_col.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/expected/documentation_auto_align_first_col.robot
@@ -8,7 +8,7 @@ Example of alignment to second column of Documentation
     ...                 note that you must give some unique column/value pair that is used to select the row
     ...
     ...                 == Examples ==
-    ...                 # makes sure chechbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
+    ...                 # makes sure checkbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
     ...                 Table_CheckboxUnSelect  Owner      Name    NORDEA FINANS
 
 Test with documentation and keyword calls

--- a/tests/atest/transformers/AlignTestCasesSection/expected/documentation_auto_skip.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/expected/documentation_auto_skip.robot
@@ -8,7 +8,7 @@ Example of alignment to second column of Documentation
     ...                 note that you must give some unique column/value pair that is used to select the row
     ...
     ...                 == Examples ==
-    ...                 # makes sure chechbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
+    ...                 # makes sure checkbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
     ...                 Table_CheckboxUnSelect  Owner      Name    NORDEA FINANS
 
 Test with documentation and keyword calls

--- a/tests/atest/transformers/AlignTestCasesSection/expected/documentation_fixed_align_first_col.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/expected/documentation_fixed_align_first_col.robot
@@ -8,7 +8,7 @@ Example of alignment to second column of Documentation
     ...                     note that you must give some unique column/value pair that is used to select the row
     ...
     ...                     == Examples ==
-    ...                     # makes sure chechbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
+    ...                     # makes sure checkbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
     ...                     Table_CheckboxUnSelect  Owner      Name    NORDEA FINANS
 
 Test with documentation and keyword calls

--- a/tests/atest/transformers/AlignTestCasesSection/expected/documentation_fixed_skip.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/expected/documentation_fixed_skip.robot
@@ -8,7 +8,7 @@ Example of alignment to second column of Documentation
     ...                 note that you must give some unique column/value pair that is used to select the row
     ...
     ...                 == Examples ==
-    ...                 # makes sure chechbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
+    ...                 # makes sure checkbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
     ...                 Table_CheckboxUnSelect  Owner      Name    NORDEA FINANS
 
 Test with documentation and keyword calls

--- a/tests/atest/transformers/AlignTestCasesSection/source/documentation.robot
+++ b/tests/atest/transformers/AlignTestCasesSection/source/documentation.robot
@@ -8,7 +8,7 @@ Example of alignment to second column of Documentation
     ...                 note that you must give some unique column/value pair that is used to select the row
     ...
     ...                 == Examples ==
-    ...                 # makes sure chechbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
+    ...                 # makes sure checkbox is unchecked in column Owner in a row where Name is "NORDEA FINANS"
     ...                 Table_CheckboxUnSelect  Owner      Name    NORDEA FINANS
 
 Test with documentation and keyword calls

--- a/tests/atest/transformers/RenameKeywords/test_transformer.py
+++ b/tests/atest/transformers/RenameKeywords/test_transformer.py
@@ -64,7 +64,7 @@ class TestRenameKeywords(TransformerAcceptanceTest):
 
     def test_embedded_with_pattern(self):
         self.compare(
-            config=":replace_pattern=(?i)rename\s?with\s.+variable$:replace_to=New_Name_${keyword}_And_${var}",
+            config=r":replace_pattern=(?i)rename\s?with\s.+variable$:replace_to=New_Name_${keyword}_And_${var}",
             source="library_embedded_var_pattern.robot",
         )
 

--- a/tests/atest/transformers/SplitTooLongLine/test_transformer.py
+++ b/tests/atest/transformers/SplitTooLongLine/test_transformer.py
@@ -93,7 +93,7 @@ class TestSplitTooLongLine(TransformerAcceptanceTest):
         self.compare(
             source="tests.robot",
             expected="skip_keywords.robot",
-            config=":line_length=80:skip_keyword_call=thisisakeyword:skip_keyword_call_pattern=(i?)sets\sthe\svariable",
+            config=r":line_length=80:skip_keyword_call=thisisakeyword:skip_keyword_call_pattern=(i?)sets\sthe\svariable",
             target_version=">=5",
         )
 

--- a/tests/utest/test_skip.py
+++ b/tests/utest/test_skip.py
@@ -50,7 +50,7 @@ class TestSkip:
         [
             ("Execute Javascript", ["Execute Javascript"], [True]),
             ("Execute Javascript", ["executejavascript"], [False]),
-            ("(?i)execute\s?javascript", ["Execute Javascript"], [True]),
+            (r"(?i)execute\s?javascript", ["Execute Javascript"], [True]),
             ("executejavascript", ["Keyword"], [False]),
             ("Javascript", ["Execute Javascript"], [True]),
             ("^Javascript", ["Execute Javascript"], [False]),
@@ -58,7 +58,7 @@ class TestSkip:
             ("Execute1", ["Execute Javascript"], [False]),
             ("Execute", ["Execute Javascript", "Execute Other Stuff", "Keyword"], [True, True, False]),
             (
-                "(?i)Library\.",
+                r"(?i)Library\.",
                 ["Library.Stuff", "Library2.Stuff", "library.Other_stuff", "library"],
                 [True, False, True, False],
             ),


### PR DESCRIPTION
One commit fixes typos; other commit fixes warnings like this one: https://github.com/MarketSquare/robotframework-tidy/actions/runs/8188111566/job/22390024839?pr=661#step:5:96