### PR TITLE
output errors on the error stream

### DIFF
--- a/robotidy/app.py
+++ b/robotidy/app.py
@@ -60,7 +60,7 @@ class Robotidy:
                     self.output_diff(model_path, old_model, new_model)
                     changed_files += 1
             except DataError as err:
-                click.echo(f"Failed to decode {source} with an error: {err}\nSkipping file")
+                click.echo(f"Failed to decode {source} with an error: {err}\nSkipping file", err=True)
                 changed_files = previous_changed_files
                 skipped_files += 1
         return self.formatting_result(all_files, changed_files, skipped_files, stdin)
@@ -78,8 +78,8 @@ class Robotidy:
             future_tense = "" if self.config.overwrite else " would be"
             click.echo(
                 f"\n{changed_files} file{changed_files_plurar}{future_tense} reformatted, "
-                f"{all_files} file{all_files_plurar}{future_tense} left unchanged." +
-                (f" {skipped_files} file{skipped_files_plurar}{future_tense} skipped." if skipped_files else "")
+                f"{all_files} file{all_files_plurar}{future_tense} left unchanged."
+                + (f" {skipped_files} file{skipped_files_plurar}{future_tense} skipped." if skipped_files else "")
             )
         if not self.config.check or not changed_files:
             return 0

--- a/robotidy/cli.py
+++ b/robotidy/cli.py
@@ -134,7 +134,7 @@ def print_description(name: str, target_version: int):
     else:
         rec_finder = misc.RecommendationFinder()
         similar = rec_finder.find_similar(name, transformer_by_names.keys())
-        click.echo(f"Transformer with the name '{name}' does not exist.{similar}")
+        click.echo(f"Transformer with the name '{name}' does not exist.{similar}", err=True)
         return 1
     return 0
 

--- a/robotidy/transformers/__init__.py
+++ b/robotidy/transformers/__init__.py
@@ -451,14 +451,16 @@ def can_run_in_robot_version(transformer, overwritten, target_version):
             click.echo(
                 f"{transformer.__class__.__name__} transformer requires Robot Framework {transformer.MIN_VERSION}.* "
                 f"version but you have {misc.ROBOT_VERSION} installed. "
-                f"Upgrade installed Robot Framework if you want to use this transformer."
+                f"Upgrade installed Robot Framework if you want to use this transformer.",
+                err=True,
             )
         else:
             click.echo(
                 f"{transformer.__class__.__name__} transformer requires Robot Framework {transformer.MIN_VERSION}.* "
                 f"version but you set --target-version rf{target_version}. "
                 f"Set --target-version to rf{transformer.MIN_VERSION} or do not forcefully enable this transformer "
-                f"with --transform / enable parameter."
+                f"with --transform / enable parameter.",
+                err=True,
             )
     return False
 

--- a/tests/atest/__init__.py
+++ b/tests/atest/__init__.py
@@ -74,7 +74,7 @@ class TransformerAcceptanceTest:
     ):
         if not self.enabled_in_version(target_version):
             pytest.skip(f"Test enabled only for RF {target_version}")
-        runner = CliRunner()
+        runner = CliRunner(mix_stderr=False)
         output_path = str(self.TRANSFORMERS_DIR / "actual" / source)
         arguments = ["--output", output_path]
         if not_modified:
@@ -116,7 +116,7 @@ class MultipleConfigsTest:
     ROOT_DIR = Path(__file__).parent / "configuration_files"
 
     def run_tidy(self, tmpdir, args: List[str] = None, exit_code: int = 0, not_modified: bool = False):
-        runner = CliRunner()
+        runner = CliRunner(mix_stderr=False)
         temporary_dir = tmpdir / self.TEST_DIR
         shutil.copytree(self.ROOT_DIR / self.TEST_DIR / "source", temporary_dir)
         arguments = []

--- a/tests/e2e/test_transform_stability.py
+++ b/tests/e2e/test_transform_stability.py
@@ -77,7 +77,7 @@ SKIP_TESTS = {
 def run_tidy(cmd, enable_disabled: bool):
     if enable_disabled:
         cmd = get_enable_disabled_config() + cmd
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     return runner.invoke(cli, cmd)
 
 

--- a/tests/utest/test_cli.py
+++ b/tests/utest/test_cli.py
@@ -303,7 +303,7 @@ class TestCli:
         expected_output = f"Transformer with the name '{name}' does not exist.{similar}"
         args = f"--desc {name} -".split()
         result = run_tidy(args, exit_code=1)
-        assert expected_output in str(result.output)
+        assert expected_output in str(result.stderr)
 
     @pytest.mark.parametrize("flag", ["--help", "-h"])
     def test_help(self, flag):
@@ -357,8 +357,8 @@ class TestCli:
         source.chmod(0o400)
         # overwrite input which is read-only file
         result = run_tidy([str(source)], overwrite_input=True)
-        assert "Permission denied" in result.output
-        assert "\n0 files reformatted, 0 files left unchanged. 1 file skipped.\n" in result.output
+        assert "Permission denied" in result.stderr
+        assert "\n0 files reformatted, 0 files left unchanged. 1 file skipped.\n" in result.stdout
 
     @pytest.mark.parametrize("color_flag", ["--color", "--no-color", None])
     @pytest.mark.parametrize("color_env", [True, False])

--- a/tests/utest/test_load_transformers.py
+++ b/tests/utest/test_load_transformers.py
@@ -260,7 +260,7 @@ class TestLoadTransformers:
                 ]
             expected_output = "".join(expected_output)
             output = capsys.readouterr()
-            assert output.out == expected_output
+            assert output.err == expected_output
 
     @pytest.mark.parametrize(
         "transform, warn_on",

--- a/tests/utest/utils.py
+++ b/tests/utest/utils.py
@@ -13,7 +13,7 @@ def run_tidy(
     std_in: Optional = None,
     overwrite_input: bool = False,
 ):
-    runner = CliRunner()
+    runner = CliRunner(mix_stderr=False)
     arguments = args if args is not None else []
     if not overwrite_input:
         if output:


### PR DESCRIPTION
This splits errors out into stderr. 

It is debatable whether all tests which currently use result.output should be adjusted to explicitly check for stderr vs stdout. I have not yet done so, except to fix the tests that would now echo to stderr.