### PR TITLE
enforce codespell checks in github actions

### DIFF
--- a/.github/workflows/code-spell.yml
+++ b/.github/workflows/code-spell.yml
@@ -12,7 +12,3 @@ jobs:
         uses: actions/checkout@v4
       - name: Codespell
         uses: codespell-project/actions-codespell@master
-        with:
-          only_warn: 1
-          skip: "pyproject_confgure.toml"
-          ignore_words_list: ba,confgure,ist,Ende,Variablen,Indention,cript


### PR DESCRIPTION
Depends on #680 

This makes passing spellcheck tests a mandatory requirement for new PRs.